### PR TITLE
Remove erroneous mutationWithUser default function

### DIFF
--- a/convex/lib/withUser.ts
+++ b/convex/lib/withUser.ts
@@ -37,10 +37,6 @@ export const withUser = <Ctx extends QueryCtx, Args extends any[], Output>(
     return await func({ ...ctx, user }, ...args);
   };
 };
-export default mutationWithUser(async ({ db, user }, body) => {
-  const message = { body, user: user._id };
-  await db.insert('messages', message);
-});
 
 /**
  * Wrapper for a Convex mutation function that provides a user in ctx.


### PR DESCRIPTION
Removed a duplicate mutationWithuser function that inserted a message into the database (seemed to be an example/boilerplate function), which was causing errors