### PR TITLE
[RLS] fix error on unique() that returns null

### DIFF
--- a/convex/lib/rowLevelSecurity.ts
+++ b/convex/lib/rowLevelSecurity.ts
@@ -206,7 +206,7 @@ class WrapQuery<T extends GenericTableInfo> implements Query<T> {
   async next(): Promise<IteratorResult<any>> {
     for (;;) {
       const { value, done } = await this.iterator!.next();
-      if (await this.p(value)) {
+      if (value && (await this.p(value))) {
         return { value, done };
       }
       if (done) {


### PR DESCRIPTION
noticed that when you call `db.query("table").filter(...).unique()` with row-level-security and there are no results, we call the row-level-security `read` predicate on `null`, which doesn't match the typescript types and isn't expected. Instead, we should only call the predicate on non-null documents.