### PR TITLE
allow empty arg for useSessionMutation too

### DIFF
--- a/src/hooks/useServerSession.ts
+++ b/src/hooks/useServerSession.ts
@@ -14,11 +14,7 @@
  */
 import React, { useContext, useEffect, useState } from "react";
 import { Id } from "../../convex/_generated/dataModel";
-import {
-  FunctionReference,
-  OptionalRestArgs,
-  makeFunctionReference,
-} from "convex/server";
+import { FunctionReference, OptionalRestArgs } from "convex/server";
 import { api } from "../../convex/_generated/api";
 import { useQuery, useMutation } from "convex/react";
 
@@ -123,9 +119,9 @@ export const useSessionMutation = <
   const originalMutation = useMutation(name);
 
   return (
-    args: SessionFunctionArgs<Mutation>
+    ...args: SessionFunctionArgsArray<Mutation>
   ): Promise<Mutation["_returnType"]> => {
-    const newArgs = { ...args, sessionId } as Mutation["_args"];
+    const newArgs = { ...(args[0] ?? {}), sessionId } as Mutation["_args"];
 
     return originalMutation(...([newArgs] as OptionalRestArgs<Mutation>));
   };


### PR DESCRIPTION
I just noticed that the session middleware now requires you pass {} as an arg if the session ID was the only arg.
useSessionQuery spreads the args. Any reason mutation shouldn't?