### PR TITLE
Add CustomCtx type helper

### DIFF
--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -538,6 +538,17 @@ type CustomBuilder<
       Visibility
     >;
 
+export type CustomCtx<Builder> = Builder extends ValidatedBuilder<
+  any,
+  any,
+  infer ModCtx,
+  any,
+  infer InputCtx,
+  any
+>
+  ? Overwrite<InputCtx, ModCtx>
+  : never;
+
 type Overwrite<T, U> = Omit<T, keyof U> & U;
 // Copied from convex/server since they weren't exported
 type EmptyObject = Record<string, never>;


### PR DESCRIPTION
I'm not sure how to test this exactly in this repo, but I tested it in mine and it works.

In my file with custom functions I can now do:

```ts
export const queryFoo = customQuery(
  baseQuery,
  customCtx(async (ctx) => {
    return {
      /// some customization....
    };
  })
);

export type QueryFooCtx = CustomCtx<typeof query>;
```