### PR TITLE
Add index to async map asyncTransform params

### DIFF
--- a/convex/relationshipsExample.ts
+++ b/convex/relationshipsExample.ts
@@ -55,7 +55,7 @@ export const relationshipTest = mutation({
     const edges = await getManyFrom(
       ctx.db,
       "join_table_example",
-      "userId",
+      "by_userId",
       userId
     );
     assertLength(edges, 2);
@@ -63,7 +63,7 @@ export const relationshipTest = mutation({
       ctx.db,
       "join_table_example",
       "sessionId",
-      "userId",
+      "by_userId",
       userId
     );
     assertLength(sessions, 2);
@@ -71,7 +71,7 @@ export const relationshipTest = mutation({
       ctx.db,
       "join_table_example",
       "sessionId",
-      "userId",
+      "by_userId",
       user2._id
     );
     assertLength(sessions2, 1);
@@ -95,7 +95,7 @@ export const relationshipTest = mutation({
         ctx.db,
         "join_table_example",
         "sessionId",
-        "userId",
+        "by_userId",
         userId
       )
     );
@@ -104,7 +104,7 @@ export const relationshipTest = mutation({
         ctx.db,
         "join_table_example",
         "sessionId",
-        "userId",
+        "by_userId",
         userId
       );
     } catch {
@@ -112,7 +112,7 @@ export const relationshipTest = mutation({
     }
     await asyncMap(edges, (edge) => ctx.db.delete(edge._id));
     await asyncMap(
-      await getManyFrom(ctx.db, "join_table_example", "userId", user2._id),
+      await getManyFrom(ctx.db, "join_table_example", "by_userId", user2._id),
       (edge) => ctx.db.delete(edge._id)
     );
     await ctx.db.delete(sessionId);
@@ -177,7 +177,7 @@ export const joinTableExample = query({
       ctx.db,
       "join_table_example",
       "sessionId",
-      "userId",
+      "by_userId",
       args.userId
     );
     const files = await getManyVia(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -12,7 +12,7 @@ const s = defineSchema({
   join_table_example: defineTable({
     userId: v.id("users"),
     sessionId: v.id("sessions"),
-  }).index("userId", ["userId"]),
+  }).index("by_userId", ["userId"]),
   join_storage_example: defineTable({
     userId: v.id("users"),
     storageId: v.id("_storage"),

--- a/packages/convex-helpers/index.ts
+++ b/packages/convex-helpers/index.ts
@@ -13,6 +13,7 @@ export async function asyncMap<FromType, ToType>(
   let index = 0;
   for (const item of list) {
     promises.push(asyncTransform(item, index));
+    index += 1;
   }
   return Promise.all(promises);
 }

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "A collection of useful code to complement the official convex package.",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A collection of useful code to complement the official convex package.",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/convex-helpers/publish.sh
+++ b/packages/convex-helpers/publish.sh
@@ -16,7 +16,8 @@ grep '"version":' package.json || {
   echo "No version number found in package.json"
   exit 1
 }
-read -p "Enter the new version number: " version
+# shellcheck disable=SC3045
+read -r -p "Enter the new version number: " version
 
 if [ -n "$version" ]; then
   sed -i '' "s/\"version\": \".*\"/\"version\": \"$version\"/g" package.json
@@ -24,7 +25,8 @@ fi
 
 npm publish --dry-run
 echo "^^^ DRY RUN ^^^"
-read -p "Publish to npm? (y/n): " publish
+# shellcheck disable=SC3045
+read -r -p "Publish to npm? (y/n): " publish
 if [ "$publish" = "y" ]; then
   git add package.json package-lock.json
   # If there's nothing to commit, continue
@@ -34,6 +36,6 @@ if [ "$publish" = "y" ]; then
   else
     npm publish
   fi
-  git tag npm/$version
+  git tag "npm/$version"
   git push --tags
 fi


### PR DESCRIPTION
I found myself wanting `asyncMap` to provide an index in `asyncTransform` props.

In my case I was updating an order column on a list of records and found it convenient to have an index while mapping over them and building a return. For instance: 

```javascript
// Update the order of all courseLessons to keep
await asyncMap(courseLessons, (cm, index) => {
   return ctx.db.patch(cm._id, { order: index + 1 });
});
```

So, this PR adds an index to the asyncTransform params on asyncMap! Might be a rare use case, but I thought I'd put it out there anyhow.

```javascript
/**
 * asyncMap returns the results of applying an async function over an list.
 *
 * @param list - Iterable object of items, e.g. an Array, Set, Object.keys
 * @param asyncTransform
 * @returns
 */
export async function asyncMap<FromType, ToType>(
  list: Iterable<FromType>,
  asyncTransform: (item: FromType, index: number) => Promise<ToType> // add index and type to param
): Promise<ToType[]> {
  const promises: Promise<ToType>[] = [];
  let index = 0; // init an index var
  for (const item of list) {
    promises.push(asyncTransform(item, index)); // return the index with the item
  }
  return Promise.all(promises);
}
```

Thanks for considering :)