### PR TITLE
Move Hono into `convex-helpers` npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are two approaches to sessions data:
 
 1. Creating a session ID client-side and passing it up to the server on every
  request. This is the [recommended approach](https://stack.convex.dev/track-sessions-without-cookies)
- and is available by **importing from `"convex-helpers/server/hono"`**.
+ and is available by **importing from `"convex-helpers/server/sessions"`**.
  See more [in the convex-helpers README](./packages/convex-helpers/README.md).
 
 2. Create a new session document in a `sessions` table for every new client,
@@ -97,11 +97,12 @@ to traverse database relationships in queries more cleanly.
 ## HTTP Endpoints: Using Hono for advanced functionality
 
 [Hono](https://hono.dev/) is an optimized web framework you can use to define
-HTTP api endpoints easily
+HTTP API endpoints easily
 ([`httpAction` in Convex](https://docs.convex.dev/functions/http-actions)).
 
 See the [guide on Stack](https://stack.convex.dev/hono-with-convex) for tips on using Hono for HTTP endpoints.
 
+**To use `convex-helpers`, import from "convex-helpers/server/hono"**
 See more [in the convex-helpers README](./packages/convex-helpers/README.md).
 
 ## Throttling client-side requests by Single-Flighting

--- a/README.md
+++ b/README.md
@@ -5,22 +5,55 @@ A collection of useful code to complement the official packages.
 ## `convex-helpers` npm package
 
 In the [packages](./packages/) directory there's the [convex-helpers](./packages/convex-helpers/)
-directory, so you can `npm install convex-helpers@latest`.
+directory. To use it:
+
+```sh
+ npm install convex-helpers@latest
+ ```
 
 It doesn't have all of the below features, but the ones it has can be used directly,
 rather than copying the code from this repo.
 
 See the [README](./packages/convex-helpers/README.md) for more details.
 
+## Custom Functions
+
+Build your own customized versions of `query`, `mutation`, and `action` that
+define custom behavior, allowing you to:
+
+- Run authentication logic before the request starts.
+- Look up commonly used data and add it to the ctx argument.
+- Replace a ctx or argument field with a different value, such as a version
+  of `db` that runs custom functions on data access.
+- Consume arguments from the client that are not passed to the action, such
+  as taking in an authentication parameter like an API key or session ID.
+  These arguments must be sent up by the client along with each request.
+
+See more [in the convex-helpers README](./packages/convex-helpers/README.md).
+
+## Zod Validation
+
+To validate your arguments with zod instead of the
+[built-in argument validation](https://stack.convex.dev/track-sessions-without-cookies),
+you can import from `convex-helpers` from `"convex-helpers/server/zod"`.
+Read more in the [Stack post](https://stack.convex.dev/typescript-zod-function-validation).
+
 ## Server-Persisted Session Data
 
-See the [guide on Stack](https://stack.convex.dev/sessions-wrappers-as-middleware) for tips on how to set up and use Sessions.
+There are two approaches to sessions data:
 
-To use sessions, check out the files:
+1. Creating a session ID client-side and passing it up to the server on every
+ request. This is the [recommended approach](https://stack.convex.dev/track-sessions-without-cookies)
+ and is available by **importing from `"convex-helpers/server/hono"`**.
+ See more [in the convex-helpers README](./packages/convex-helpers/README.md).
 
-- [server/sessions.ts](./packages/convex-helpers/server/sessions.ts) on the server-side to give you action utilities like `ctx.runSessionQuery(...)`.
-- [react/session.ts](./packages/convex-helpers/react/sessions.ts) on the client-side to give you hooks like `useSessionMutation(...)`.
-- You'll need to define a table in your [`convex/schema.ts`](./convex/schema.ts) for whatever your session data looks like. Here we just use `{}`.
+2. Create a new session document in a `sessions` table for every new client,
+ where you can store associated data.
+ See [this article on Stack](https://stack.convex.dev/sessions-wrappers-as-middleware)
+ for tips on how to set up and use Sessions. To use theses sessions, copy the files:
+    - [server/sessions.ts](./packages/convex-helpers/server/sessions.ts) on the server-side to give you action utilities like `ctx.runSessionQuery(...)`.
+    - [react/session.ts](./packages/convex-helpers/react/sessions.ts) on the client-side to give you hooks like `useSessionMutation(...)`.
+    - You'll need to define a table in your [`convex/schema.ts`](./convex/schema.ts) for whatever your session data looks like. Here we just use `{}`.
 
 ## Authentication: withUser
 
@@ -56,15 +89,20 @@ See the [Stack post on relationship helpers](https://stack.convex.dev/functional
 and the [relationship schema structures post](https://stack.convex.dev/relationship-structures-let-s-talk-about-schemas).
 
 **To use `convex-helpers`, import from "convex-helpers/server/relationships"**
+See more [in the convex-helpers README](./packages/convex-helpers/README.md).
 
-To copy code:
-Use the helpers in [relationships.ts](./packages/convex-helpers/server/relationships.ts) to traverse database relationships in queries more cleanly.
+To copy code: Use [relationships.ts](./packages/convex-helpers/server/relationships.ts)
+to traverse database relationships in queries more cleanly.
 
 ## HTTP Endpoints: Using Hono for advanced functionality
 
+[Hono](https://hono.dev/) is an optimized web framework you can use to define
+HTTP api endpoints easily
+([`httpAction` in Convex](https://docs.convex.dev/functions/http-actions)).
+
 See the [guide on Stack](https://stack.convex.dev/hono-with-convex) for tips on using Hono for HTTP endpoints.
 
-To use Hono, you'll need the file [honoWithConvex.ts](./convex/lib/honoWithConvex.ts).
+See more [in the convex-helpers README](./packages/convex-helpers/README.md).
 
 ## Throttling client-side requests by Single-Flighting
 
@@ -89,10 +127,21 @@ Related files:
 - (optional)[useTypingIndicator.ts](./src/hooks/useTypingIndicator.ts) for specifically doing typing indicator presence.
 - (optional)[Facepile.tsx](./src/components/Facepile.tsx) for showing a facepile based on presence data. Intended to be used as an example to extend.
 
-## Zod Validation
+## Validator utilities
 
-Update: now Convex has argument validation. If you are just checking types, it
-should suffice: https://docs.convex.dev/functions/args-validation
-See the [Stack post on Zod validation](https://stack.convex.dev/wrappers-as-middleware-zod-validation) to see how to validate your Convex functions using the [zod](https://www.npmjs.com/package/zod) library.
+When using validators for defining database schema or function arguments,
+these validators help:
 
-You'll need the [withZod.ts](./convex/lib/withZod.ts) file.
+1. Add a `Table` utility that defines a table and keeps references to the fields
+to avoid re-defining validators. To learn more about sharing validators, read
+[this article](https://stack.convex.dev/argument-validation-without-repetition),
+an extension of [this article](https://stack.convex.dev/types-cookbook).
+2. Add utilties for partial, pick and omit to match the TypeScript type
+utilities.
+3. Add shorthand for a union of `literals`, a `nullable` field, a `deprecated`
+field, and `brandedString`. To learn more about branded strings see
+[this article](https://stack.convex.dev/using-branded-types-in-validators).
+4. Make the validators look more like TypeScript types, even though they're
+runtime values. (This is controvercial and not required to use the above).
+
+See more [in the convex-helpers README](./packages/convex-helpers/README.md).

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,7 +17,6 @@ import type {
 import type * as counter from "../counter.js";
 import type * as customFunctionExample from "../customFunctionExample.js";
 import type * as http from "../http.js";
-import type * as lib_honoWithConvex from "../lib/honoWithConvex.js";
 import type * as lib_migrations from "../lib/migrations.js";
 import type * as lib_rowLevelSecurity from "../lib/rowLevelSecurity.js";
 import type * as lib_withUser from "../lib/withUser.js";
@@ -40,7 +39,6 @@ declare const fullApi: ApiFromModules<{
   counter: typeof counter;
   customFunctionExample: typeof customFunctionExample;
   http: typeof http;
-  "lib/honoWithConvex": typeof lib_honoWithConvex;
   "lib/migrations": typeof lib_migrations;
   "lib/rowLevelSecurity": typeof lib_rowLevelSecurity;
   "lib/withUser": typeof lib_withUser;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono";
-import { HonoWithConvex, HttpRouterWithHono } from "./lib/honoWithConvex";
+import { HonoWithConvex, HttpRouterWithHono } from "convex-helpers/server/hono";
+import { ActionCtx } from "./_generated/server";
 
-const app: HonoWithConvex = new Hono();
+const app: HonoWithConvex<ActionCtx> = new Hono();
 
-// See the [Stack post on using Hono](https://stack.convex.dev)
+// See the [guide on Stack](https://stack.convex.dev/hono-with-convex)
+// for tips on using Hono for HTTP endpoints.
 app.get("/", async (c) => {
   return c.json("Hello world!");
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,9 +1,14 @@
-import { Hono } from "hono";
-import { HonoWithConvex, HttpRouterWithHono } from "convex-helpers/server/hono";
-import { ActionCtx } from "./_generated/server";
+import {
+  Hono,
+  HonoWithConvex,
+  HttpRouterWithHono,
+} from "convex-helpers/server/hono";
+import { cors } from "hono/cors";
+import { ActionCtx, query } from "./_generated/server";
 
 const app: HonoWithConvex<ActionCtx> = new Hono();
 
+app.use("/*", cors());
 // See the [guide on Stack](https://stack.convex.dev/hono-with-convex)
 // for tips on using Hono for HTTP endpoints.
 app.get("/", async (c) => {
@@ -11,3 +16,13 @@ app.get("/", async (c) => {
 });
 
 export default new HttpRouterWithHono(app);
+
+/**
+ * Helper for testing.
+ */
+export const siteUrl = query({
+  args: {},
+  handler: async () => {
+    return process.env.CONVEX_SITE_URL;
+  },
+});

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -136,6 +136,35 @@ export const myComplexQuery = zodQuery({
 })
 ```
 
+## Hono for advanced HTTP endpoint definitions
+
+[Hono](https://hono.dev/) is an optimized web framework you can use to define
+HTTP api endpoints easily
+([`httpAction` in Convex](https://docs.convex.dev/functions/http-actions)).
+
+See the [guide on Stack](https://stack.convex.dev/hono-with-convex) for tips on using Hono for HTTP endpoints.
+
+To use it, put this in your `convex/http.ts` file:
+```ts
+import {
+  Hono,
+  HonoWithConvex,
+  HttpRouterWithHono,
+} from "convex-helpers/server/hono";
+import { ActionCtx } from "./_generated/server";
+
+const app: HonoWithConvex<ActionCtx> = new Hono();
+
+// See the [guide on Stack](https://stack.convex.dev/hono-with-convex)
+// for tips on using Hono for HTTP endpoints.
+app.get("/", async (c) => {
+  return c.json("Hello world!");
+});
+
+export default new HttpRouterWithHono(app);
+```
+
+
 ## Validator utilities
 
 When using validators for defining database schema or function arguments,
@@ -145,18 +174,17 @@ these validators help:
 to avoid re-defining validators. To learn more about sharing validators, read
 [this article](https://stack.convex.dev/argument-validation-without-repetition),
 an extension of [this article](https://stack.convex.dev/types-cookbook).
-2. Make the validators look more like TypeScript types, even though they're
-runtime values.
-3. Add utilties for partial, pick and omit to match the TypeScript type
+2. Add utilties for partial, pick and omit to match the TypeScript type
 utilities.
-4. Add shorthand for a union of `literals`, a `nullable` field, a `deprecated`
+3. Add shorthand for a union of `literals`, a `nullable` field, a `deprecated`
 field, and `brandedString`. To learn more about branded strings see
 [this article](https://stack.convex.dev/using-branded-types-in-validators).
+4. Make the validators look more like TypeScript types, even though they're
+runtime values. (This is controvercial and not required to use the above).
 
 Example:
 ```js
 import { Table } from "convex-helpers/server";
-// Note some redefinitions in the import for even more terse definitions.
 import {
   literals, partial, deprecated, brandedString,
 } from "convex-helpers/validators";

--- a/packages/convex-helpers/package-lock.json
+++ b/packages/convex-helpers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "convex-helpers",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "devDependencies": {
         "chokidar-cli": "^3.0.0",

--- a/packages/convex-helpers/package-lock.json
+++ b/packages/convex-helpers/package-lock.json
@@ -14,10 +14,14 @@
       },
       "peerDependencies": {
         "convex": "^1.9.1",
+        "hono": "^4.0.5",
         "react": "^17.0.2 || ^18.0.0",
         "zod": "^3.22.4"
       },
       "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -660,6 +664,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.0.5.tgz",
+      "integrity": "sha512-6LEGL1Pf3+dLjVA0NJxAB/3FJ6S3W5qxd/XOG7Wl9YOrpMRZT9lt83R4Ojs8dO6GbAUSutI7zTyjStnSn9sbEg==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/is-binary-path": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -10,6 +10,7 @@
     "./server": "./dist/server/index.js",
     "./server*": "./dist/server*",
     "./server/customFunctions": "./dist/server/customFunctions.js",
+    "./server/hono": "./dist/server/hono.js",
     "./server/middlewareUtils": "./dist/server/middlewareUtils.js",
     "./server/rowLevelSecurity": "./dist/server/rowLevelSecurity.js",
     "./server/relationships": "./dist/server/relationships.js",

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -50,10 +50,14 @@
   "homepage": "https://github.com/get-convex/convex-helpers/tree/main/packages/convex-helpers/README.md",
   "peerDependencies": {
     "convex": "^1.9.1",
+    "hono": "^4.0.5",
     "react": "^17.0.2 || ^18.0.0",
     "zod": "^3.22.4"
   },
   "peerDependenciesMeta": {
+    "hono": {
+      "optional": true
+    },
     "react": {
       "optional": true
     },

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "A collection of useful code to complement the official convex package.",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/convex-helpers/server/hono.ts
+++ b/packages/convex-helpers/server/hono.ts
@@ -6,8 +6,11 @@
  *
  * To use this helper, create a new Hono app in convex/http.ts like so:
  * ```ts
- * import { Hono } from "hono";
- * import { HonoWithConvex, HttpRouterWithHono } from "convex-helpers/server/hono";
+ * import {
+ *   Hono,
+ *   HonoWithConvex,
+ *   HttpRouterWithHono,
+ * } from "convex-helpers/server/hono";
  * import { ActionCtx } from "./_generated/server";
  *
  * const app: HonoWithConvex<ActionCtx> = new Hono();
@@ -28,6 +31,7 @@ import {
   GenericActionCtx,
 } from "convex/server";
 import { Hono } from "hono";
+export { Hono };
 
 /**
  * Hono uses the `FetchEvent` type internally, which has to do with service workers

--- a/packages/convex-helpers/server/hono.ts
+++ b/packages/convex-helpers/server/hono.ts
@@ -1,12 +1,33 @@
-// Taken from https://github.com/get-convex/convex-helpers/blob/main/convex/lib/honoWithConvex.ts
+/**
+ * This file contains a helper class for integrating Convex with Hono.
+ *
+ * See the [guide on Stack](https://stack.convex.dev/hono-with-convex)
+ * for tips on using Hono for HTTP endpoints.
+ *
+ * To use this helper, create a new Hono app in convex/http.ts like so:
+ * ```ts
+ * import { Hono } from "hono";
+ * import { HonoWithConvex, HttpRouterWithHono } from "convex-helpers/server/hono";
+ * import { ActionCtx } from "./_generated/server";
+ *
+ * const app: HonoWithConvex<ActionCtx> = new Hono();
+ *
+ * app.get("/", async (c) => {
+ *   return c.json("Hello world!");
+ * });
+ *
+ * export default new HttpRouterWithHono(app);
+ * ```
+ */
 import {
+  httpActionGeneric,
   HttpRouter,
   PublicHttpAction,
   RoutableMethod,
   ROUTABLE_HTTP_METHODS,
+  GenericActionCtx,
 } from "convex/server";
 import { Hono } from "hono";
-import { httpAction, ActionCtx } from "../_generated/server";
 
 /**
  * Hono uses the `FetchEvent` type internally, which has to do with service workers
@@ -22,7 +43,7 @@ declare global {
  * A type representing a Hono app with `c.env` containing Convex's
  * `HttpEndpointCtx` (e.g. `c.env.runQuery` is valid).
  */
-export type HonoWithConvex = Hono<{
+export type HonoWithConvex<ActionCtx extends GenericActionCtx<any>> = Hono<{
   Bindings: {
     [Name in keyof ActionCtx]: ActionCtx[Name];
   };
@@ -56,17 +77,19 @@ export type HonoWithConvex = Hono<{
  * export default new HttpRouterWithHono(app);
  * ```
  */
-export class HttpRouterWithHono extends HttpRouter {
-  private _app: HonoWithConvex;
+export class HttpRouterWithHono<
+  ActionCtx extends GenericActionCtx<any>
+> extends HttpRouter {
+  private _app: HonoWithConvex<ActionCtx>;
   private _handler: PublicHttpAction;
   private _handlerInfoCache: Map<any, { method: RoutableMethod; path: string }>;
 
-  constructor(app: HonoWithConvex) {
+  constructor(app: HonoWithConvex<ActionCtx>) {
     super();
     this._app = app;
     // Single Convex httpEndpoint handler that just forwards the request to the
     // Hono framework
-    this._handler = httpAction(async (ctx, request: Request) => {
+    this._handler = httpActionGeneric(async (ctx, request: Request) => {
       return await app.fetch(request, ctx);
     });
     this._handlerInfoCache = new Map();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import Counter from "./components/Counter";
 import RelationshipExample from "./components/RelationshipExample";
 import SessionsExample from "./components/SessionsExample";
 import ZodExample from "./components/ZodExample";
+import { HonoExample } from "./components/HonoExample";
 
 export default function App() {
   return (
@@ -10,6 +11,7 @@ export default function App() {
       <ZodExample />
       <RelationshipExample />
       <SessionsExample />
+      <HonoExample />
     </main>
   );
 }

--- a/src/components/HonoExample.tsx
+++ b/src/components/HonoExample.tsx
@@ -1,0 +1,23 @@
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { useEffect, useState } from "react";
+
+export function HonoExample() {
+  const siteUrl = useQuery(api.http.siteUrl);
+  const [value, setValue] = useState("");
+  useEffect(() => {
+    if (!siteUrl) return;
+    fetch(`${siteUrl}/`)
+      .then((r) => r.text())
+      .then(setValue);
+  }, [siteUrl]);
+
+  return (
+    <div>
+      <h2>Hono Example</h2>
+      <p>
+        Value fetching from {siteUrl}/: {value}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Allows using hono without copy-paste. It is now parameterized by `ActionCtx` when declaring it, instead of importing from a generated file.