### PR TITLE
Add Retries helpers and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ find the npm package in [./packages/convex-helpers](./packages/convex-helpers).
 | [CRUD](./packages/convex-helpers/README.md#crud-utilities) | [Stable query results via useStableQuery](#stable-query-results-via-usestablequery) |
 | [Validator utilities](./packages/convex-helpers/README.md#validator-utilities) |
 | [Filter db queries with JS](./packages/convex-helpers/README.md#filter) |
+| [Action retry wrapper](./packages/convex-helpers/README.md#action-retries) |
 
 ## `convex-helpers` [npm package](https://www.npmjs.com/package/convex-helpers)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ There are two approaches to sessions data:
     - [react/session.ts](./packages/convex-helpers/react/sessions.ts) on the client-side to give you hooks like `useSessionMutation(...)`.
     - You'll need to define a table in your [`convex/schema.ts`](./convex/schema.ts) for whatever your session data looks like. Here we just use `{}`.
 
+## Retrying actions
+
+Use helper functions to retry a Convex action until it succeeds.
+
+See the [Stack post on retrying actions](https://stack.convex.dev/retry-actions)
+and the [convex-helpers package README](./packages/convex-helpers/README.md)
+for examples and usage.
+
 ## Authentication: withUser
 
 See the [Stack post on withUser](https://stack.convex.dev/wrappers-as-middleware-authentication)

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as lib_withUser from "../lib/withUser.js";
 import type * as lib_withZod from "../lib/withZod.js";
 import type * as presence from "../presence.js";
 import type * as relationshipsExample from "../relationshipsExample.js";
+import type * as retriesExample from "../retriesExample.js";
 import type * as rowLevelSecurityExample from "../rowLevelSecurityExample.js";
 import type * as sessionsExample from "../sessionsExample.js";
 import type * as testingFunctions from "../testingFunctions.js";
@@ -51,6 +52,7 @@ declare const fullApi: ApiFromModules<{
   "lib/withZod": typeof lib_withZod;
   presence: typeof presence;
   relationshipsExample: typeof relationshipsExample;
+  retriesExample: typeof retriesExample;
   rowLevelSecurityExample: typeof rowLevelSecurityExample;
   sessionsExample: typeof sessionsExample;
   testingFunctions: typeof testingFunctions;

--- a/convex/retriesExample.ts
+++ b/convex/retriesExample.ts
@@ -6,7 +6,8 @@ import { makeActionRetrier } from "convex-helpers/server/retries";
 
 // Export the helpers, with the name of the retry function.
 export const { runWithRetries, retry } = makeActionRetrier(
-  "retriesExample:retry"
+  "retriesExample:retry",
+  { retryBackoff: 1000 } // set to 1 second for demo purposes.
 );
 
 // This is a sample action will fail randomly based on the `failureRate`
@@ -22,21 +23,68 @@ export const unreliableAction = internalAction({
   },
 });
 
-// Call this to call the `unreliableAction` function with retries.
+// This calls the `unreliableAction` function with retries.
+// Try it for yourself with:
 // e.g. `npx convex run retriesExample:runUnreliableActionWithRetries`
 export const runUnreliableActionWithRetries = mutation({
-  args: { failureRate: v.optional(v.number()) },
+  args: {},
   handler: async (ctx, args) => {
+    await runWithRetries(ctx, internal.retriesExample.unreliableAction, {
+      failureRate: 0.8,
+    });
+    // Possibly do something else besides scheduling the action,
+    // for instance check if the logged in user has permission to run it.
+    // If an error is thrown in a mutation, the transaction will be rolled back
+    // and the action will not be scheduled to run.
+  },
+});
+
+// Calling an action with retries from an action works too.
+export const runFromAnAction = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const email = { to: "user@example.com", subject: "Hello", body: "World" };
     await runWithRetries(
       ctx,
-      internal.retriesExample.unreliableAction,
+      internal.retriesExample.sendWelcomeEmail,
+      { email },
       {
-        failureRate: args.failureRate ?? 0.8,
-      },
-      {
-        maxFailures: 4,
-        retryBackoff: 1000,
+        // You can limit the number of retries and wait longer between attempts
+        // if the action is not time sensitive and generally reliable.
+        // Note: generally the default options are fine.
+
+        // After 5 failures, give up.
+        maxFailures: 5,
+        // Wait 10 seconds before retrying the first time.
+        retryBackoff: 10_000,
+        // This is the multiplier for the next wait time.
+        // e.g. if base is 10, the next wait time will be 10 times the previous.
+        base: 10,
+        // Wait time is then retryBackoff * base^(retryNumber).
+        // This will result in waiting:
+        // 10 seconds before retrying the first time,
+        // 100 seconds before retrying the second time (~1.7 minutes),
+        // 1000 seconds before retrying the third time (~16.7 minutes),
+        // 10000 seconds before retrying the fourth and final time (~2.7 hours),
+        // giving the action 5 chances to succeed over ~3 hours.
       }
     );
+    // Unlike in mutations, in an action the scheduler will immediately be
+    // given the action & parameters to run, even if there's an exception thrown
+    // afterwards.
+  },
+});
+
+// This is a pretend email sending function.
+export const sendWelcomeEmail = internalAction({
+  args: {
+    email: v.object({ to: v.string(), subject: v.string(), body: v.string() }),
+  },
+  handler: async () => {
+    // If the email provider is down, it could fail.
+    // Hopefully it will be back up within minutes, but if it still isn't up
+    // hours later, it's ok to skip sending this non-essential.
+    // Note: If we wanted to ensure we don't send the same email twice,
+    // we would need something like an idempotency key to pass to the provider.
   },
 });

--- a/convex/retriesExample.ts
+++ b/convex/retriesExample.ts
@@ -1,0 +1,53 @@
+import { v } from "convex/values";
+import { api, internal } from "./_generated/api";
+import { Doc, Id } from "./_generated/dataModel";
+import {
+  action,
+  internalAction,
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from "./_generated/server";
+
+import { makeActionRetrier } from "convex-helpers/server/retries";
+
+// Export the helpers, with the name of the retry function.
+export const { runWithRetries, retry } = makeActionRetrier(
+  internalMutation,
+  "retriesExample:retry"
+);
+
+// This is a sample action will fail randomly based on the `failureRate`
+// argument. It's safe to retry since it doesn't have any side effects.
+export const unreliableAction = internalAction({
+  args: {
+    failureRate: v.number(), // 0.0 - 1.0
+  },
+  handler: async (_ctx, { failureRate }) => {
+    console.log("Running an action with failure rate " + failureRate);
+    if (Math.random() < failureRate) {
+      throw new Error("action failed.");
+    }
+    console.log("action succeded.");
+  },
+});
+
+// Call this to call the `unreliableAction` function with retries.
+// e.g. `npx convex run retriesExample:runUnreliableActionWithRetries`
+export const runUnreliableActionWithRetries = mutation({
+  args: { failureRate: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    await runWithRetries(
+      ctx,
+      internal.retriesExample.unreliableAction,
+      {
+        failureRate: args.failureRate ?? 0.8,
+      },
+      {
+        maxFailures: 4,
+        retryBackoff: 1000,
+      }
+    );
+  },
+});

--- a/convex/retriesExample.ts
+++ b/convex/retriesExample.ts
@@ -1,14 +1,6 @@
 import { v } from "convex/values";
-import { api, internal } from "./_generated/api";
-import { Doc, Id } from "./_generated/dataModel";
-import {
-  action,
-  internalAction,
-  internalMutation,
-  internalQuery,
-  mutation,
-  query,
-} from "./_generated/server";
+import { internal } from "./_generated/api";
+import { internalAction, mutation } from "./_generated/server";
 
 import { makeActionRetrier } from "convex-helpers/server/retries";
 

--- a/convex/retriesExample.ts
+++ b/convex/retriesExample.ts
@@ -7,7 +7,7 @@ import { makeActionRetrier } from "convex-helpers/server/retries";
 // Export the helpers, with the name of the retry function.
 export const { runWithRetries, retry } = makeActionRetrier(
   "retriesExample:retry",
-  { retryBackoff: 1000 } // set to 1 second for demo purposes.
+  { retryBackoff: 1000, log: console.warn } // options for demo purposes.
 );
 
 // This is a sample action will fail randomly based on the `failureRate`

--- a/convex/retriesExample.ts
+++ b/convex/retriesExample.ts
@@ -12,9 +12,7 @@ export const { runWithRetries, retry } = makeActionRetrier(
 // This is a sample action will fail randomly based on the `failureRate`
 // argument. It's safe to retry since it doesn't have any side effects.
 export const unreliableAction = internalAction({
-  args: {
-    failureRate: v.number(), // 0.0 - 1.0
-  },
+  args: { failureRate: v.number() }, // 0.0 - 1.0
   handler: async (_ctx, { failureRate }) => {
     console.log("Running an action with failure rate " + failureRate);
     if (Math.random() < failureRate) {

--- a/convex/retriesExample.ts
+++ b/convex/retriesExample.ts
@@ -14,7 +14,6 @@ import { makeActionRetrier } from "convex-helpers/server/retries";
 
 // Export the helpers, with the name of the retry function.
 export const { runWithRetries, retry } = makeActionRetrier(
-  internalMutation,
   "retriesExample:retry"
 );
 

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -91,9 +91,8 @@ Example:
 ```ts
  // in convex/utils.ts
  import { makeActionRetrier } from "convex-helpers/server/retries";
- import { internalMutation } from "./convex/_generated/server";
 
- export const { runWithRetries, retry } = makeActionRetrier(internalMutation, internal.utils.retry);
+ export const { runWithRetries, retry } = makeActionRetrier("utils:retry");
 
  // in a mutation or action
  export const myMutation = mutation({

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -79,6 +79,33 @@ const posts = await asyncMap(
 );
 ```
 
+## Action retries
+
+Use helper functions to retry a Convex action until it succeeds.
+An action should only be retried if it is safe to do so, i.e., if it's
+idempotent or doesn't have any unsafe side effects.
+
+See the [Stack post on retrying actions](https://stack.convex.dev/retry-actions)
+
+Example:
+```ts
+ // in convex/utils.ts
+ import { makeActionRetrier } from "convex-helpers/server/retries";
+ import { internalMutation } from "./convex/_generated/server";
+
+ export const { runWithRetries, retry } = makeActionRetrier(internalMutation, internal.utils.retry);
+
+ // in a mutation or action
+ export const myMutation = mutation({
+   args: {...},
+   handler: async (ctx, args) => {
+     //...
+     await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });
+   }
+ });
+
+```
+
 ## Session tracking via client-side sessionID storage
 
 Store a session ID on the client and pass it up with requests to keep track of

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -15,6 +15,7 @@
     "./server/middlewareUtils": "./dist/server/middlewareUtils.js",
     "./server/rowLevelSecurity": "./dist/server/rowLevelSecurity.js",
     "./server/relationships": "./dist/server/relationships.js",
+    "./server/retries": "./dist/server/retries.js",
     "./server/sessions": "./dist/server/sessions.js",
     "./server/zod": "./dist/server/zod.js",
     "./testing": "./dist/testing.js",

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -13,6 +13,7 @@
 import { ObjectType, PropertyValidators } from "convex/values";
 import {
   ActionBuilder,
+  DefaultFunctionArgs,
   FunctionVisibility,
   GenericActionCtx,
   GenericDataModel,
@@ -557,4 +558,3 @@ export type CustomCtx<Builder> = Builder extends ValidatedBuilder<
   : never;
 
 type Overwrite<T, U> = Omit<T, keyof U> & U;
-type DefaultFunctionArgs = Record<string, unknown>;

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -30,7 +30,7 @@ const DEFAULT_MAX_FAILURES = 16;
  *
  * export const { runWithRetries, retry } = makeActionRetrier("utils:retry");
  *
- * // in a mutation or action
+ * // in a mutation
  * await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });
  * ```
  *
@@ -46,6 +46,12 @@ export function makeActionRetrier(retryFnName: string) {
   >(retryFnName);
   /**
    * Run and retry action until it succeeds or fails too many times.
+   *
+   * If this is called from a mutation, it will be run and retried up to
+   * options.maxFailures times (default 16).
+   * If it's called from an action, there is a chance that the action will
+   * be called once but not retried. To ensure that the action is retried,
+   * it should be wrapped in an internal mutation if called from an action.
    *
    * @param action - Name of the action to run, e.g., `usercode:maybeAction`.
    * @param actionArgs - Arguments to pass to the action, e.g., `{"failureRate": 0.75}`.

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -16,8 +16,6 @@
  * ```
  */
 import {
-  GenericDataModel,
-  MutationBuilder,
   FunctionReference,
   FunctionVisibility,
   Scheduler,
@@ -26,6 +24,7 @@ import {
   getFunctionName,
   makeFunctionReference,
   DefaultFunctionArgs,
+  internalMutationGeneric,
 } from "convex/server";
 import { v, ObjectType } from "convex/values";
 
@@ -62,10 +61,7 @@ const retryArguments = {
  * e.g. internal.mymodule.retry
  * @returns An object with runWithRetries and retry functions.
  */
-export function makeActionRetrier<
-  DataModel extends GenericDataModel,
-  InternalMutation extends MutationBuilder<DataModel, "internal">
->(internalMutation: InternalMutation, retryFnName: string) {
+export function makeActionRetrier(retryFnName: string) {
   const retryRef = makeFunctionReference<
     "action",
     ObjectType<typeof retryArguments>
@@ -116,7 +112,7 @@ export function makeActionRetrier<
     });
   }
 
-  const retry = internalMutation({
+  const retry = internalMutationGeneric({
     args: retryArguments,
     handler: async (ctx, args) => {
       const { job } = args;

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -1,0 +1,175 @@
+/**
+ * This file defines helper functions that can be used to retry a
+ * Convex action until it succeeds. An action should only be retried if it is
+ * safe to do so, i.e., if it's idempotent or doesn't have any unsafe side effects.
+ *
+ * Used like:
+ * ```ts
+ * // in convex/utils.ts
+ * import { makeActionRetrier } from "convex-helpers/server/retries";
+ * import { internalMutation } from "./convex/_generated/server";
+ *
+ * export const { runWithRetries, retry } = makeActionRetrier(internalMutation, internal.utils.retry);
+ *
+ * // in a mutation or action
+ * await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });
+ * ```
+ */
+import {
+  GenericDataModel,
+  MutationBuilder,
+  FunctionReference,
+  FunctionVisibility,
+  Scheduler,
+  FunctionArgs,
+  OptionalRestArgs,
+  getFunctionName,
+  makeFunctionReference,
+  DefaultFunctionArgs,
+} from "convex/server";
+import { v, ObjectType } from "convex/values";
+
+const DEFAULT_WAIT_BACKOFF = 10;
+const DEFAULT_RETRY_BACKOFF = 10;
+const DEFAULT_BASE = 2;
+const DEFAULT_MAX_FAILURES = 16;
+const retryArguments = {
+  job: v.id("_scheduled_functions"),
+  action: v.string(),
+  actionArgs: v.any(),
+  waitBackoff: v.number(),
+  retryBackoff: v.number(),
+  base: v.number(),
+  maxFailures: v.number(),
+};
+
+/**
+ * Create a function that retries an action with exponential backoff.
+ * e.g.
+ * ```ts
+ * // in convex/utils.ts
+ * import { makeActionRetrier } from "convex-helpers/server/retries";
+ * import { internalMutation } from "./convex/_generated/server";
+ *
+ * export const { runWithRetries, retry } = makeActionRetrier(internalMutation, internal.utils.retry);
+ *
+ * // in a mutation or action
+ * await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });
+ * ```
+ *
+ * @param internalMutation From "./convex/_generated/server" or customMutation.
+ * @param retryRef The function reference to the retryRef function exported.
+ * e.g. internal.mymodule.retry
+ * @returns An object with runWithRetries and retry functions.
+ */
+export function makeActionRetrier<
+  DataModel extends GenericDataModel,
+  InternalMutation extends MutationBuilder<DataModel, "internal">
+>(internalMutation: InternalMutation, retryFnName: string) {
+  const retryRef = makeFunctionReference<
+    "action",
+    ObjectType<typeof retryArguments>
+  >(retryFnName);
+  /**
+   * Run and retry action until it succeeds or fails too many times.
+   *
+   * @param action - Name of the action to run, e.g., `usercode:maybeAction`.
+   * @param actionArgs - Arguments to pass to the action, e.g., `{"failureRate": 0.75}`.
+   * @param options
+   * @param options.waitBackoff=DEFAULT_WAIT_BACKOFF (10) - Initial delay before checking action status, in milliseconds.
+   * @param options.retryBackoff=DEFAULT_RETRY_BACKOFF (10) - Initial delay before retrying, in milliseconds.
+   * @param options.base=DEFAULT_BASE (2) - Base of the exponential backoff.
+   * @param options.maxFailures=DEFAULT_MAX_FAILURES (16) - The maximum number of times to retry the action.
+   */
+  async function runWithRetries<
+    Action extends FunctionReference<
+      "action",
+      Visibility,
+      DefaultFunctionArgs,
+      null | Promise<null> | void | Promise<void>
+    >,
+    Visibility extends FunctionVisibility = "internal"
+  >(
+    ctx: { scheduler: Scheduler },
+    action: Action,
+    actionArgs: FunctionArgs<Action>,
+    options?: {
+      waitBackoff?: number;
+      retryBackoff?: number;
+      base?: number;
+      maxFailures?: number;
+    }
+  ) {
+    const job = await ctx.scheduler.runAfter(
+      0,
+      action,
+      ...([actionArgs] as OptionalRestArgs<Action>)
+    );
+    await ctx.scheduler.runAfter(0, retryRef, {
+      job,
+      action: getFunctionName(action),
+      actionArgs,
+      waitBackoff: options?.waitBackoff ?? DEFAULT_WAIT_BACKOFF,
+      retryBackoff: options?.retryBackoff ?? DEFAULT_RETRY_BACKOFF,
+      base: options?.base ?? DEFAULT_BASE,
+      maxFailures: options?.maxFailures ?? DEFAULT_MAX_FAILURES,
+    });
+  }
+
+  const retry = internalMutation({
+    args: retryArguments,
+    handler: async (ctx, args) => {
+      const { job } = args;
+      const status = await ctx.db.system.get(job);
+      if (!status) {
+        throw new Error(`Job ${job} not found`);
+      }
+
+      switch (status.state.kind) {
+        case "pending":
+        case "inProgress":
+          console.log(
+            `Job ${job} not yet complete, checking again in ${args.waitBackoff} ms.`
+          );
+          await ctx.scheduler.runAfter(args.waitBackoff, retryRef, {
+            ...args,
+            waitBackoff: args.waitBackoff * args.base,
+          });
+          break;
+
+        case "failed":
+          if (args.maxFailures <= 0) {
+            console.log(`Job ${job} failed too many times, not retrying.`);
+            break;
+          }
+          console.log(
+            `Job ${job} failed, retrying in ${args.retryBackoff} ms.`
+          );
+          const newJob = await ctx.scheduler.runAfter(
+            args.retryBackoff,
+            makeFunctionReference<"action">(args.action),
+            args.actionArgs
+          );
+          await ctx.scheduler.runAfter(args.retryBackoff, retryRef, {
+            ...args,
+            job: newJob,
+            retryBackoff: args.retryBackoff * args.base,
+            maxFailures: args.maxFailures - 1,
+          });
+          break;
+
+        case "success":
+          console.log(`Job ${job} succeeded.`);
+          break;
+        case "canceled":
+          console.log(`Job ${job} was canceled. Not retrying.`);
+          break;
+      }
+    },
+  });
+
+  return {
+    runWithRetries,
+    retry,
+  };
+}

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -166,12 +166,16 @@ export function makeActionRetrier(
             `Job ${args.action}(${job}) failed, ` +
               `retrying in ${args.retryBackoff} ms as ${newJob}.`
           );
-          await ctx.scheduler.runAfter(args.retryBackoff, retryRef, {
-            ...args,
-            job: newJob,
-            retryBackoff: args.retryBackoff * args.base,
-            maxFailures: args.maxFailures - 1,
-          });
+          await ctx.scheduler.runAfter(
+            args.retryBackoff + args.waitBackoff,
+            retryRef,
+            {
+              ...args,
+              job: newJob,
+              retryBackoff: args.retryBackoff * args.base,
+              maxFailures: args.maxFailures - 1,
+            }
+          );
           break;
 
         case "success":

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -50,11 +50,11 @@ export function makeActionRetrier(retryFnName: string) {
    * If this is called from a mutation, it will be run and retried up to
    * options.maxFailures times (default 16).
    * If it's called from an action, there is a chance that the action will
-   * be called once but not retried. To ensure that the action is retried,
-   * it should be wrapped in an internal mutation if called from an action.
+   * be called once but not retried. To ensure that the action is retried when
+   * calling from an action, * it should be wrapped in an internal mutation.
    *
-   * @param action - Name of the action to run, e.g., `usercode:maybeAction`.
-   * @param actionArgs - Arguments to pass to the action, e.g., `{"failureRate": 0.75}`.
+   * @param action - Name of the action to run, e.g., `"usercode:maybeAction"`.
+   * @param actionArgs - Arguments for the action, e.g., `{ failureRate: 0.75}`.
    * @param options
    * @param options.waitBackoff=DEFAULT_WAIT_BACKOFF (10) - Initial delay before checking action status, in milliseconds.
    * @param options.retryBackoff=DEFAULT_RETRY_BACKOFF (10) - Initial delay before retrying, in milliseconds.

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -16,8 +16,8 @@ import {
 } from "convex/server";
 import { v, ObjectType } from "convex/values";
 
-const DEFAULT_WAIT_BACKOFF = 10;
-const DEFAULT_RETRY_BACKOFF = 10;
+const DEFAULT_WAIT_BACKOFF = 100;
+const DEFAULT_RETRY_BACKOFF = 100;
 const DEFAULT_BASE = 2;
 const DEFAULT_MAX_FAILURES = 16;
 
@@ -34,9 +34,8 @@ const DEFAULT_MAX_FAILURES = 16;
  * await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });
  * ```
  *
- * @param internalMutation From "./convex/_generated/server" or customMutation.
- * @param retryRef The function reference to the retryRef function exported.
- * e.g. internal.mymodule.retry
+ * @param retryFnName The function name of the retry function exported.
+ * e.g. "myFolder/myUtilModule:retry"
  * @returns An object with runWithRetries and retry functions.
  */
 export function makeActionRetrier(retryFnName: string) {
@@ -51,7 +50,7 @@ export function makeActionRetrier(retryFnName: string) {
    * options.maxFailures times (default 16).
    * If it's called from an action, there is a chance that the action will
    * be called once but not retried. To ensure that the action is retried when
-   * calling from an action, * it should be wrapped in an internal mutation.
+   * calling from an action, it should be wrapped in an internal mutation.
    *
    * @param action - Name of the action to run, e.g., `"usercode:maybeAction"`.
    * @param actionArgs - Arguments for the action, e.g., `{ failureRate: 0.75}`.

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -2,18 +2,6 @@
  * This file defines helper functions that can be used to retry a
  * Convex action until it succeeds. An action should only be retried if it is
  * safe to do so, i.e., if it's idempotent or doesn't have any unsafe side effects.
- *
- * Used like:
- * ```ts
- * // in convex/utils.ts
- * import { makeActionRetrier } from "convex-helpers/server/retries";
- * import { internalMutation } from "./convex/_generated/server";
- *
- * export const { runWithRetries, retry } = makeActionRetrier(internalMutation, internal.utils.retry);
- *
- * // in a mutation or action
- * await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });
- * ```
  */
 import {
   FunctionReference,
@@ -39,9 +27,8 @@ const DEFAULT_MAX_FAILURES = 16;
  * ```ts
  * // in convex/utils.ts
  * import { makeActionRetrier } from "convex-helpers/server/retries";
- * import { internalMutation } from "./convex/_generated/server";
  *
- * export const { runWithRetries, retry } = makeActionRetrier(internalMutation, internal.utils.retry);
+ * export const { runWithRetries, retry } = makeActionRetrier("utils:retry");
  *
  * // in a mutation or action
  * await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -7,7 +7,6 @@ import {
   FunctionReference,
   FunctionVisibility,
   Scheduler,
-  FunctionArgs,
   getFunctionName,
   makeFunctionReference,
   DefaultFunctionArgs,
@@ -79,14 +78,15 @@ export function makeActionRetrier(
     Action extends FunctionReference<
       "action",
       Visibility,
-      DefaultFunctionArgs,
+      Args,
       null | Promise<null> | void | Promise<void>
     >,
+    Args extends DefaultFunctionArgs,
     Visibility extends FunctionVisibility = "internal"
   >(
     ctx: { scheduler: Scheduler },
     action: Action,
-    actionArgs: FunctionArgs<Action>,
+    actionArgs: Args,
     options?: {
       waitBackoff?: number;
       retryBackoff?: number;

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -30,13 +30,22 @@ const DEFAULTS = {
  *
  * export const { runWithRetries, retry } = makeActionRetrier("utils:retry");
  *
- * // in a mutation
+ * // in a mutation or action
  * await runWithRetries(ctx, internal.myModule.myAction, { arg1: 123 });
  * ```
  *
  * @param retryFnName The function name of the retry function exported.
  * e.g. "myFolder/myUtilModule:retry"
- * @returns An object with runWithRetries and retry functions.
+ * @param defaultOptions - Options for the retry behavior. Defaults to:
+ *  { waitBackoff: 100, retryBackoff: 100, base: 2, maxFailures: 16 }
+ * @param defaultOptions.waitBackoff - Initial delay before checking action
+ *   status, in milliseconds. Defaults to 100.
+ * @param defaultOptions.retryBackoff - Initial delay before retrying
+ *   a failure, in milliseconds. Defaults to 100.
+ * @param defaultOptions.base - Base of the exponential backoff. Defaults to 2.
+ * @param defaultOptions.maxFailures - The maximum number of times to retry failures.
+ *   Defaults to 16.
+ * @returns An object with runWithRetries and retry functions to export.
  */
 export function makeActionRetrier(
   retryFnName: string,

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -143,7 +143,7 @@ export function makeActionRetrier(
             `Job ${args.action}(${job}) not yet complete, ` +
               `checking again in ${args.waitBackoff} ms.`
           );
-          await ctx.scheduler.runAfter(args.waitBackoff, retryRef, {
+          await ctx.scheduler.runAfter(withJitter(args.waitBackoff), retryRef, {
             ...args,
             job,
             waitBackoff: args.waitBackoff * args.base,
@@ -158,7 +158,7 @@ export function makeActionRetrier(
             break;
           }
           const newJob = await ctx.scheduler.runAfter(
-            args.retryBackoff,
+            withJitter(args.retryBackoff),
             makeFunctionReference<"action">(args.action),
             args.actionArgs
           );
@@ -167,7 +167,7 @@ export function makeActionRetrier(
               `retrying in ${args.retryBackoff} ms as ${newJob}.`
           );
           await ctx.scheduler.runAfter(
-            args.retryBackoff + args.waitBackoff,
+            withJitter(args.retryBackoff + args.waitBackoff),
             retryRef,
             {
               ...args,
@@ -194,4 +194,8 @@ export function makeActionRetrier(
     runWithRetries,
     retry,
   };
+}
+
+export function withJitter(delay: number) {
+  return delay * (0.5 + Math.random());
 }

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -32,15 +32,6 @@ const DEFAULT_WAIT_BACKOFF = 10;
 const DEFAULT_RETRY_BACKOFF = 10;
 const DEFAULT_BASE = 2;
 const DEFAULT_MAX_FAILURES = 16;
-const retryArguments = {
-  job: v.id("_scheduled_functions"),
-  action: v.string(),
-  actionArgs: v.any(),
-  waitBackoff: v.number(),
-  retryBackoff: v.number(),
-  base: v.number(),
-  maxFailures: v.number(),
-};
 
 /**
  * Create a function that retries an action with exponential backoff.
@@ -112,6 +103,15 @@ export function makeActionRetrier(retryFnName: string) {
     });
   }
 
+  const retryArguments = {
+    job: v.id("_scheduled_functions"),
+    action: v.string(),
+    actionArgs: v.any(),
+    waitBackoff: v.number(),
+    retryBackoff: v.number(),
+    base: v.number(),
+    maxFailures: v.number(),
+  };
   const retry = internalMutationGeneric({
     args: retryArguments,
     handler: async (ctx, args) => {

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -13,6 +13,7 @@ import {
   internalMutationGeneric,
 } from "convex/server";
 import { v, ObjectType } from "convex/values";
+import { omit } from "..";
 
 const DEFAULTS = {
   waitBackoff: 100,
@@ -62,7 +63,7 @@ export function makeActionRetrier(
     "action",
     ObjectType<typeof retryArguments>
   >(retryFnName);
-  const defaults = { ...DEFAULTS, ...options };
+  const defaults = { ...DEFAULTS, ...omit(options ?? {}, ["log"]) };
   const log = options?.log ?? (() => {});
   /**
    * Run and retry action until it succeeds or fails too many times.


### PR DESCRIPTION
Adds the retry helpers from https://github.com/JamesCowling/convex-action-retrier
Changes the API to instead of exposing a mutation to run, expose a type-safe function that schedules both, whether you're in an action or mutation. The only risk with this is if you call it from an action and the scheduler succeeds on the first but fails the retrier on the second, and the called action fails, which seems exceedingly unlikely. 