### PR TITLE
Make `npm run test` pass

### DIFF
--- a/src/components/Counter.mock.test.tsx
+++ b/src/components/Counter.mock.test.tsx
@@ -2,6 +2,7 @@ import Counter from "./Counter";
 import { render } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import * as convexReact from "convex/react";
+import { FunctionReference, getFunctionName } from "convex/server";
 
 // Keep track of counter values
 let counters: Record<string, number> = {};
@@ -34,14 +35,14 @@ vi.mock("convex/react", async () => {
 
   return {
     ...actual,
-    useQuery: (queryName: string, args: Record<string, any>) => {
-      if (queryName !== "counter:getCounter") {
+    useQuery: (queryName: FunctionReference<"query", "public">, args: Record<string, any>) => {
+      if (getFunctionName(queryName) !== "counter:getCounter") {
         throw new Error("Unexpected query call!");
       }
       return getCounter(args as any);
     },
-    useMutation: (mutationName: string) => {
-      if (mutationName !== "counter:incrementCounter") {
+    useMutation: (mutationName: FunctionReference<"mutation", "public">) => {
+      if (getFunctionName(mutationName)  !== "counter:incrementCounter") {
         throw new Error("Unexpected mutation call!");
       }
       return incrementCounterMock;

--- a/src/fakeConvexClient/fakeConvexClient.js
+++ b/src/fakeConvexClient/fakeConvexClient.js
@@ -23,7 +23,8 @@ export class ConvexReactClientFake {
     throw new Error("Auth is not implemented");
   }
 
-  watchQuery(name, args) {
+  watchQuery(functionReference, args) {
+    const name = getFunctionName(functionReference);
     return {
       localQueryResult: () => {
         const query = this.queries && this.queries[name];
@@ -43,26 +44,22 @@ export class ConvexReactClientFake {
     };
   }
 
-  mutation(name) {
+  mutation(functionReference, args) {
+    const name = getFunctionName(functionReference);
     const mutation = this.mutations && this.mutations[name];
     if (mutation) {
-      const mut = (args) => mutation(args);
-
-      const withOptimisticUpdate = mutation.withOptimisticUpdate
-        ? mutation.withOptimisticUpdate
-        : () => mut;
-      mut.withOptimisticUpdate = withOptimisticUpdate;
-      return mut;
+      return mutation(args)
     }
     throw new Error(
       `Unexpected mutation: ${name}. Try providing a function for this mutation in the mock client constructor.`
     );
   }
 
-  action(name) {
+  action(functionReference, args) {
+    const name = getFunctionName(functionReference);
     const action = this.actions && this.actions[name];
     if (action) {
-      return action;
+      return action(args);
     }
     throw new Error(
       `Unexpected action: ${name}. Try providing a function for this actionin the mock client constructor.`

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -6,5 +6,9 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    // These contain `.test.ts` files that are not actual
+    // vitest tests
+    exclude: ["packages\/convex-helpers\/server\/**", "**\/node_modules\/**"],
+    passWithNoTests: true
   },
 });


### PR DESCRIPTION
We have several `.test.ts` files that aren't actually vitest tests, one of which does not actually run (`zod.test`).

This excludes them. This also fixes the fake ConvexReactClient + mock test.