### PR TITLE
pretend validators

### DIFF
--- a/convex/validatorsExample.ts
+++ b/convex/validatorsExample.ts
@@ -76,7 +76,7 @@ export const testUser = (
   balance: null,
   ephemeral: false,
   status: "active",
-  maybeNotSetYet: undefined as any,
+  maybeNotSetYet: undefined as unknown as string,
   couldBeAnything: 123 as any,
   loginType: {
     type: "email",

--- a/convex/validatorsExample.ts
+++ b/convex/validatorsExample.ts
@@ -17,6 +17,8 @@ import {
   array,
   object,
   brandedString,
+  pretendRequired,
+  pretend,
 } from "convex-helpers/validators";
 import { assert, omit, pick } from "convex-helpers";
 import {
@@ -44,6 +46,8 @@ export const Users = Table("users", {
   ephemeral: boolean,
   status: literals("active", "inactive"),
   rawJSON: optional(any),
+  maybeNotSetYet: pretendRequired(string),
+  couldBeAnything: pretend(boolean),
   loginType: or(
     object({
       type: is("email"),
@@ -72,6 +76,8 @@ export const testUser = (
   balance: null,
   ephemeral: false,
   status: "active",
+  maybeNotSetYet: undefined as any,
+  couldBeAnything: 123 as any,
   loginType: {
     type: "email",
     email: "test@example.com" as Email,


### PR DESCRIPTION
Adds convenience validators for when you don't mind some targeted incorrectness, esp. while you do migrations

Can be part of a post on pragmatic migration dev tips. Saves you from turning on & off schemaValidation.

Flow to add a field:

1. Add `myField: pretendRequired(v.string()),` and code that sets & uses myField as if it exists[ and a migration to set it].
2. Deploy & change the data in the dashboard [or run the migration]
3. Some time later, take off the `pretendRequired` wrapper and deploy.

Improves over the following in that you don't have to sprinkle `if` statements everywhere:

1. Add `myField: v.optional(v.string())` and code that handles it not being there[ and a migration to set it].
2. Same as above
3. Update the code to assume it's there (take out all the `if(!doc.newField) throw ...` lines) and deploy.

Flow to change a field's type:

1. Add `myField: pretend(v.number())` and code that assumes number, and a migration to change string -> number.
2. Same as above
3. Remove the `pretend` and deploy.

This saves you from changing all of your code to handle the union, just in order to deploy something that allows you to edit data in the dashboard.