### PR TITLE
Dual package

### DIFF
--- a/packages/convex-helpers/generate-exports.mjs
+++ b/packages/convex-helpers/generate-exports.mjs
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(new URL(import.meta.url)));
+
+function directoryContents(dirname) {
+  return fs
+    .readdirSync(path.join(__dirname, dirname))
+    .filter((filename) => filename.endsWith(".ts"))
+    .filter((filename) => !filename.includes(".test"))
+    .map((filename) => path.join(dirname, filename));
+}
+
+function entryPointFiles() {
+  return [
+    "./index.ts",
+    "./testing.ts",
+    "./validators.ts",
+    ...directoryContents("react"),
+    ...directoryContents("server"),
+  ];
+}
+
+function indent(s, n) {
+  const lines = s.split("\n");
+  return (
+    lines.shift() + "\n" + lines.map((line) => " ".repeat(n) + line).join("\n")
+  );
+}
+
+function entryPointFromFile(source) {
+  let entryPoint = path.join(path.parse(source).dir, path.parse(source).name);
+
+  if (path.parse(source).name === "index") {
+    entryPoint = path.parse(source).dir;
+  }
+
+  if (!entryPoint.startsWith(".")) {
+    entryPoint = `./${entryPoint}`;
+  }
+
+  return entryPoint;
+}
+
+function generateExport(source) {
+  let extensionless = path.join(
+    path.parse(source).dir,
+    path.parse(source).name
+  );
+
+  return {
+    types: {
+      module: `./dist/esm-types/${extensionless}.d.ts`,
+      default: `./dist/cjs-types/${extensionless}.d.ts`,
+    },
+    development: `./${extensionless}.ts`,
+    module: `./dist/esm/${extensionless}.js`,
+    default: `./dist/cjs/${extensionless}.js`,
+  };
+}
+
+function generateExports() {
+  const obj = {};
+  for (const entryPoint of entryPointFiles()) {
+    obj[entryPointFromFile(entryPoint)] = generateExport(entryPoint);
+  }
+  return obj;
+}
+
+function checkPackageJsonExports() {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "package.json"))
+  );
+  const actual = packageJson.exports;
+  const expected = generateExports();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    console.error("-------------------->8--------------------");
+    console.log(
+      `  "exports": ${indent(JSON.stringify(expected, null, 2), 2)},`
+    );
+    console.error("-------------------->8--------------------");
+    console.error(
+      "`package.json` exports are not correct. Copy exports from above or run"
+    );
+    console.error("node generate-exports.mjs | pbcopy");
+    console.error("and paste into package.json.");
+    process.exit(1);
+  }
+}
+
+checkPackageJsonExports();

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -31,7 +31,8 @@
     "prebuild": "npm run test",
     "test": "tsc --project tsconfig.test.json",
     "clean": "rm -rf dist",
-    "watch": "chokidar '*.ts' 'server/*.ts' 'react/*.ts' 'tsconfig.json' 'package.json' -c 'npm run build' --initial"
+    "watch": "chokidar '*.ts' 'server/*.ts' 'react/*.ts' 'tsconfig.json' 'package.json' -c 'npm run build' --initial",
+    "arethetypeswrong": "npx attw $(npm pack)"
   },
   "repository": {
     "type": "git",
@@ -69,5 +70,8 @@
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "typescript": "^5.3"
+  },
+  "dependencies": {
+    "@arethetypeswrong/cli": "^0.15.2"
   }
 }

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -3,20 +3,123 @@
   "version": "0.1.27",
   "description": "A collection of useful code to complement the official convex package.",
   "exports": {
-    ".": "./dist/index.js",
-    "./react/sessions": "./dist/react/sessions.js",
-    "./server": "./dist/server/index.js",
-    "./server/customFunctions": "./dist/server/customFunctions.js",
-    "./server/filter": "./dist/server/filter.js",
-    "./server/hono": "./dist/server/hono.js",
-    "./server/middlewareUtils": "./dist/server/middlewareUtils.js",
-    "./server/rowLevelSecurity": "./dist/server/rowLevelSecurity.js",
-    "./server/relationships": "./dist/server/relationships.js",
-    "./server/retries": "./dist/server/retries.js",
-    "./server/sessions": "./dist/server/sessions.js",
-    "./server/zod": "./dist/server/zod.js",
-    "./testing": "./dist/testing.js",
-    "./validators": "./dist/validators.js"
+    ".": {
+      "types": {
+        "module": "./dist/esm-types/index.d.ts",
+        "default": "./dist/cjs-types/index.d.ts"
+      },
+      "development": "./index.ts",
+      "module": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./testing": {
+      "types": {
+        "module": "./dist/esm-types/testing.d.ts",
+        "default": "./dist/cjs-types/testing.d.ts"
+      },
+      "development": "./testing.ts",
+      "module": "./dist/esm/testing.js",
+      "default": "./dist/cjs/testing.js"
+    },
+    "./validators": {
+      "types": {
+        "module": "./dist/esm-types/validators.d.ts",
+        "default": "./dist/cjs-types/validators.d.ts"
+      },
+      "development": "./validators.ts",
+      "module": "./dist/esm/validators.js",
+      "default": "./dist/cjs/validators.js"
+    },
+    "./react/sessions": {
+      "types": {
+        "module": "./dist/esm-types/react/sessions.d.ts",
+        "default": "./dist/cjs-types/react/sessions.d.ts"
+      },
+      "development": "./react/sessions.ts",
+      "module": "./dist/esm/react/sessions.js",
+      "default": "./dist/cjs/react/sessions.js"
+    },
+    "./server/customFunctions": {
+      "types": {
+        "module": "./dist/esm-types/server/customFunctions.d.ts",
+        "default": "./dist/cjs-types/server/customFunctions.d.ts"
+      },
+      "development": "./server/customFunctions.ts",
+      "module": "./dist/esm/server/customFunctions.js",
+      "default": "./dist/cjs/server/customFunctions.js"
+    },
+    "./server/filter": {
+      "types": {
+        "module": "./dist/esm-types/server/filter.d.ts",
+        "default": "./dist/cjs-types/server/filter.d.ts"
+      },
+      "development": "./server/filter.ts",
+      "module": "./dist/esm/server/filter.js",
+      "default": "./dist/cjs/server/filter.js"
+    },
+    "./server/hono": {
+      "types": {
+        "module": "./dist/esm-types/server/hono.d.ts",
+        "default": "./dist/cjs-types/server/hono.d.ts"
+      },
+      "development": "./server/hono.ts",
+      "module": "./dist/esm/server/hono.js",
+      "default": "./dist/cjs/server/hono.js"
+    },
+    "./server": {
+      "types": {
+        "module": "./dist/esm-types/server/index.d.ts",
+        "default": "./dist/cjs-types/server/index.d.ts"
+      },
+      "development": "./server/index.ts",
+      "module": "./dist/esm/server/index.js",
+      "default": "./dist/cjs/server/index.js"
+    },
+    "./server/relationships": {
+      "types": {
+        "module": "./dist/esm-types/server/relationships.d.ts",
+        "default": "./dist/cjs-types/server/relationships.d.ts"
+      },
+      "development": "./server/relationships.ts",
+      "module": "./dist/esm/server/relationships.js",
+      "default": "./dist/cjs/server/relationships.js"
+    },
+    "./server/retries": {
+      "types": {
+        "module": "./dist/esm-types/server/retries.d.ts",
+        "default": "./dist/cjs-types/server/retries.d.ts"
+      },
+      "development": "./server/retries.ts",
+      "module": "./dist/esm/server/retries.js",
+      "default": "./dist/cjs/server/retries.js"
+    },
+    "./server/rowLevelSecurity": {
+      "types": {
+        "module": "./dist/esm-types/server/rowLevelSecurity.d.ts",
+        "default": "./dist/cjs-types/server/rowLevelSecurity.d.ts"
+      },
+      "development": "./server/rowLevelSecurity.ts",
+      "module": "./dist/esm/server/rowLevelSecurity.js",
+      "default": "./dist/cjs/server/rowLevelSecurity.js"
+    },
+    "./server/sessions": {
+      "types": {
+        "module": "./dist/esm-types/server/sessions.d.ts",
+        "default": "./dist/cjs-types/server/sessions.d.ts"
+      },
+      "development": "./server/sessions.ts",
+      "module": "./dist/esm/server/sessions.js",
+      "default": "./dist/cjs/server/sessions.js"
+    },
+    "./server/zod": {
+      "types": {
+        "module": "./dist/esm-types/server/zod.d.ts",
+        "default": "./dist/cjs-types/server/zod.d.ts"
+      },
+      "development": "./server/zod.ts",
+      "module": "./dist/esm/server/zod.js",
+      "default": "./dist/cjs/server/zod.js"
+    }
   },
   "files": [
     "dist",
@@ -27,11 +130,11 @@
     "validators.ts"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "node generate-exports.mjs && tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.types.esm.json ./tsconfig.types.cjs.json; echo '{\"type\": \"module\"}' > ./dist/esm/package.json; echo '{\"type\": \"module\"}' > ./dist/esm-types/package.json",
     "prebuild": "npm run test",
     "test": "tsc --project tsconfig.test.json",
     "clean": "rm -rf dist",
-    "watch": "chokidar '*.ts' 'server/*.ts' 'react/*.ts' 'tsconfig.json' 'package.json' -c 'npm run build' --initial",
+    "watch": "chokidar '*.ts' 'server/*.ts' 'react/*.ts' 'tsconfig*.json' 'package.json' -c 'npm run build' --initial",
     "arethetypeswrong": "npx attw $(npm pack)"
   },
   "repository": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -4,11 +4,8 @@
   "description": "A collection of useful code to complement the official convex package.",
   "exports": {
     ".": "./dist/index.js",
-    "./react": "./dist/react/index.js",
-    "./react*": "./dist/react*",
     "./react/sessions": "./dist/react/sessions.js",
     "./server": "./dist/server/index.js",
-    "./server*": "./dist/server*",
     "./server/customFunctions": "./dist/server/customFunctions.js",
     "./server/filter": "./dist/server/filter.js",
     "./server/hono": "./dist/server/hono.js",

--- a/packages/convex-helpers/tsconfig.cjs.json
+++ b/packages/convex-helpers/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "CommonJS",
+    "noEmit": false
+  }
+}

--- a/packages/convex-helpers/tsconfig.esm.json
+++ b/packages/convex-helpers/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "esnext",
+    "noEmit": false
+  }
+}

--- a/packages/convex-helpers/tsconfig.types.cjs.json
+++ b/packages/convex-helpers/tsconfig.types.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs-types",
+    "module": "CommonJS",
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/convex-helpers/tsconfig.types.esm.json
+++ b/packages/convex-helpers/tsconfig.types.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm-types",
+    "module": "esnext",
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
Compile ESM and CJS builds and types and use exports to point to them.

This resolves the warnings [here](https://arethetypeswrong.github.io/?p=convex-helpers%400.1.27) and makes ts-jest work in https://github.com/get-convex/convex-chess/pull/19/files without adding the exception not to compile these files.

I'm not sure this needs to be a dual package though. If we could get away with ESM-only the build would be simpler. That's the way we should recommend developers build things in Convex.