### PR TITLE
Sessions

### DIFF
--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -101,10 +101,12 @@ export const SessionProvider: React.FC<{
     ssrFriendly ? undefined : idGen()
   );
 
+  const [initial, setInitial] = useState(true);
   // Generate a new session ID on first load.
   // This is to get around SSR issues with localStorage.
   useEffect(() => {
     if (!sessionId || sessionId === SSR_DEFAULT) setSessionId(idGen());
+    if (ssrFriendly && initial) setInitial(false);
   }, [setSessionId, sessionId]);
 
   const refreshSessionId = useCallback<RefreshSessionFn>(
@@ -120,7 +122,8 @@ export const SessionProvider: React.FC<{
   );
   const value = useMemo(
     () => ({
-      sessionId: sessionId || SSR_DEFAULT,
+      sessionId:
+        ssrFriendly && initial ? SSR_DEFAULT : sessionId || SSR_DEFAULT,
       refreshSessionId,
     }),
     [sessionId, refreshSessionId]

--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -70,7 +70,7 @@ export const SSR_DEFAULT = "SSR default session ID" as SessionId;
  * Context for a Convex session, creating a server session and providing the id.
  *
  * @param useStorage - Where you want your session ID to be persisted. Roughly:
- *  - sessionStorage is saved per-tab
+ *  - sessionStorage is saved per-tab (default).
  *  - localStorage is shared between tabs, but not browser profiles.
  * @param storageKey - Key under which to store the session ID in the store
  * @param idGenerator - Function to return a new, unique session ID string. Defaults to crypto.randomUUID
@@ -83,7 +83,7 @@ export const SSR_DEFAULT = "SSR default session ID" as SessionId;
  * To be used with useSessionQuery and useSessionMutation.
  */
 export const SessionProvider: React.FC<{
-  useStorage?: UseStorage<SessionId>;
+  useStorage?: UseStorage<SessionId | undefined>;
   storageKey?: string;
   idGenerator?: () => string;
   ssrFriendly?: boolean;
@@ -98,18 +98,14 @@ export const SessionProvider: React.FC<{
   const useStorageOrDefault = useStorage ?? useSessionStorage;
   const [sessionId, setSessionId] = useStorageOrDefault(
     storeKey,
-    ssrFriendly ? SSR_DEFAULT : idGen()
+    ssrFriendly ? undefined : idGen()
   );
 
-  const [initial, setInitial] = useState(true);
-  if (ssrFriendly) {
-    // Generate a new session ID on first load.
-    // This is to get around SSR issues with localStorage.
-    useEffect(() => {
-      if (sessionId === SSR_DEFAULT) setSessionId(idGen());
-      if (initial) setInitial(false);
-    }, [setSessionId, sessionId, setInitial, initial]);
-  }
+  // Generate a new session ID on first load.
+  // This is to get around SSR issues with localStorage.
+  useEffect(() => {
+    if (!sessionId || sessionId === SSR_DEFAULT) setSessionId(idGen());
+  }, [setSessionId, sessionId]);
 
   const refreshSessionId = useCallback<RefreshSessionFn>(
     async (beforeUpdate) => {
@@ -124,10 +120,10 @@ export const SessionProvider: React.FC<{
   );
   const value = useMemo(
     () => ({
-      sessionId: initial && ssrFriendly ? SSR_DEFAULT : sessionId,
+      sessionId: sessionId || SSR_DEFAULT,
       refreshSessionId,
     }),
-    [initial, ssrFriendly, sessionId, refreshSessionId]
+    [sessionId, refreshSessionId]
   );
 
   return React.createElement(SessionContext.Provider, { value }, children);
@@ -199,14 +195,20 @@ export function useSessionId() {
   return [ctx.sessionId, ctx.refreshSessionId] as const;
 }
 
-export function useSessionStorage(key: string, initialValue: SessionId) {
+export function useSessionStorage(
+  key: string,
+  initialValue: SessionId | undefined
+) {
   const [value, setValueInternal] = useState(() => {
     if (typeof sessionStorage !== "undefined") {
       const existing = sessionStorage.getItem(key);
       if (existing) {
+        if (existing === "undefined") {
+          return undefined;
+        }
         return existing as SessionId;
       }
-      sessionStorage.setItem(key, initialValue);
+      if (initialValue !== undefined) sessionStorage.setItem(key, initialValue);
     }
     return initialValue;
   });

--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -126,7 +126,7 @@ export const SessionProvider: React.FC<{
         ssrFriendly && initial ? SSR_DEFAULT : sessionId || SSR_DEFAULT,
       refreshSessionId,
     }),
-    [sessionId, refreshSessionId]
+    [ssrFriendly, initial, sessionId, refreshSessionId]
   );
 
   return React.createElement(SessionContext.Provider, { value }, children);

--- a/packages/convex-helpers/server/migrations.ts
+++ b/packages/convex-helpers/server/migrations.ts
@@ -129,7 +129,7 @@ export function makeMigration<
    * passed into migrateOne.
    * Optionally specify a custom batch size to override the default.
    *
-   * e.g.
+   * In convex/migrations.ts for example:
    * ```ts
    * // in convex/migrations.ts for example
    * export const myMigration = migration({

--- a/src/components/SessionsExample.tsx
+++ b/src/components/SessionsExample.tsx
@@ -4,8 +4,9 @@ import {
   useSessionQuery,
 } from "convex-helpers/react/sessions";
 import { api } from "../../convex/_generated/api";
-import { useMutation } from "convex/react";
+import { SessionProvider } from "convex-helpers/react/sessions";
 import { useState } from "react";
+// import { useLocalStorage } from "usehooks-ts";
 
 export default () => {
   const [sessionId, refreshSessionId] = useSessionId();
@@ -15,7 +16,10 @@ export default () => {
   const joinRoom = useSessionMutation(api.sessionsExample.joinRoom);
   const [room, setRoom] = useState("");
   return (
-    <>
+    <SessionProvider
+    // storageKey={"ConvexSessionId"}
+    // useStorage={useLocalStorage}
+    >
       <h2>Sessions Example</h2>
       <span>{sessionId}</span>
       <button
@@ -44,6 +48,6 @@ export default () => {
       <button onClick={() => refreshSessionId((newSessionId) => logout())}>
         Delete Session Data on Log Out
       </button>
-    </>
+    </SessionProvider>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,20 +3,13 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import { ConvexProvider, ConvexReactClient } from "convex/react";
-import { SessionProvider } from "convex-helpers/react/sessions";
-// import { useLocalStorage } from "usehooks-ts";
 
 const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ConvexProvider client={convex}>
-      <SessionProvider
-      // storageKey={"ConvexSessionId"}
-      // useStorage={useLocalStorage}
-      >
-        <App />
-      </SessionProvider>
+      <App />
     </ConvexProvider>
   </StrictMode>
 );


### PR DESCRIPTION
Store the session ID as undefined by default, rather than the weird string.

Previously if your app didn't successfully execute the useEffect you'd end up with the SSR_DEFAULT in your localstorage and just keep using that later. 

Also some feedback from @xixixao 