### PR TITLE
sessionIdPromise instead of throwing

### DIFF
--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -47,6 +47,7 @@ export type RefreshSessionFn = (
 const SessionContext = React.createContext<{
   sessionId: SessionId | undefined;
   refreshSessionId: RefreshSessionFn;
+  sessionIdPromise: Promise<SessionId>;
   ssrFriendly?: boolean;
 } | null>(null);
 
@@ -72,12 +73,16 @@ type SessionArgsArray<Fn extends SessionFunction<"mutation" | "action">> =
  *  - sessionStorage is saved per-tab (default).
  *  - localStorage is shared between tabs, but not browser profiles.
  * @param storageKey - Key under which to store the session ID in the store
- * @param idGenerator - Function to return a new, unique session ID string. Defaults to crypto.randomUUID
- * @param ssrFriendly - Returns SSR_DEFAULT on the first pass, so hydration
- *   doesn't mismatch and an ID isn't generated server-side.
- *   useSessionQuery will skip queries until there is a real value.
- *   However, if you're using useSessionId, consider checking for SSR_DEFAULT.
- *   Defaults to false, where it will always return a valid id.
+ * @param idGenerator - Function to return a new, unique session ID string.
+ *   Defaults to crypto.randomUUID (which isn't always available for server SSR)
+ * @param ssrFriendly - Set this if you're using SSR. Defaults to false.
+ *   The sessionId won't be available on the server, so the server render and
+ *   first client render will have undefined sessionId. During this render:
+ *   1. {@link useSessionQuery} will wait for a valid ID via "skip".
+ *   2. {@link useSessionMutation} and {@link useSessionAction} will wait for
+ *      a valid ID via a promise if called from the first pass.
+ *   3. {@link useSessionId} will return undefined for the sessionId along with
+ *      the promise to await for the valid ID.
  * @returns A provider to wrap your React nodes which provides the session ID.
  * To be used with useSessionQuery and useSessionMutation.
  */
@@ -99,12 +104,22 @@ export const SessionProvider: React.FC<{
     storeKey,
     ssrFriendly ? undefined : idGen()
   );
+  const [sessionIdPromise, resolveSessionId] = useMemo(() => {
+    if (sessionId) return [Promise.resolve(sessionId), (_: SessionId) => {}];
+    let resolve: (value: SessionId) => void;
+    const promise = new Promise<SessionId>((r) => (resolve = r));
+    return [promise, resolve!];
+  }, [sessionId]);
 
   const [initial, setInitial] = useState(true);
   // Generate a new session ID on first load.
   // This is to get around SSR issues with localStorage.
   useEffect(() => {
-    if (!sessionId) setSessionId(idGen());
+    if (!sessionId) {
+      const newId = idGen();
+      setSessionId(newId);
+      resolveSessionId(newId);
+    }
     if (ssrFriendly && initial) setInitial(false);
   }, [setSessionId, sessionId]);
 
@@ -123,21 +138,30 @@ export const SessionProvider: React.FC<{
     () => ({
       sessionId: ssrFriendly && initial ? undefined : sessionId,
       refreshSessionId,
+      sessionIdPromise,
       ssrFriendly,
     }),
-    [ssrFriendly, initial, sessionId, refreshSessionId]
+    [ssrFriendly, initial, sessionId, refreshSessionId, sessionIdPromise]
   );
 
   return React.createElement(SessionContext.Provider, { value }, children);
 };
 
-// Like useQuery, but for a Query that takes a session ID.
+/**
+ * Use this in place of {@link useQuery} to run a query, passing a sessionId.
+ *
+ * It automatically injects the sessionid parameter.
+ * @param query Query that takes in a sessionId parameter. Like `api.foo.bar`.
+ * @param args Args for that query, without the sessionId.
+ * @returns A query result. For SSR, it will skip the query until the
+ * second render.
+ */
 export function useSessionQuery<Query extends SessionFunction<"query">>(
   query: Query,
   ...args: SessionQueryArgsArray<Query>
 ): FunctionReturnType<Query> | undefined {
-  const [sessionId] = useSessionId("ssr");
-  const skip = args[0] === "skip" || sessionId === undefined;
+  const [sessionId] = useSessionId();
+  const skip = args[0] === "skip" || !sessionId;
   const originalArgs = args[0] === "skip" ? {} : args[0] ?? {};
 
   const newArgs = skip ? "skip" : { ...originalArgs, sessionId };
@@ -145,23 +169,28 @@ export function useSessionQuery<Query extends SessionFunction<"query">>(
   return useQuery(query, ...([newArgs] as OptionalRestArgs<Query>));
 }
 
-// Like useMutation, but for a Mutation that takes a session ID.
+/**
+ * Use this in place of {@link useMutation} to run a mutation with a sessionId.
+ *
+ * It automatically injects the sessionId parameter.
+ * @param mutation Mutation that takes in a sessionId parameter. Like `api.foo.bar`.
+ * @param args Args for that mutation, without the sessionId.
+ * @returns A mutation result. For SSR, it will wait until the client has a
+ * valid sessionId.
+ */
 export function useSessionMutation<
   Mutation extends SessionFunction<"mutation">,
 >(name: Mutation) {
-  const [sessionId] = useSessionId("ssr");
+  const [sessionId, _, sessionIdPromise] = useSessionId();
   const originalMutation = useMutation(name);
 
   return useCallback(
-    (
+    async (
       ...args: SessionArgsArray<Mutation>
     ): Promise<FunctionReturnType<Mutation>> => {
-      if (sessionId === undefined) {
-        throw new Error("useSessionMutation: Session ID is not available yet.");
-      }
       const newArgs = {
         ...(args[0] ?? {}),
-        sessionId,
+        sessionId: sessionId || (await sessionIdPromise),
       } as FunctionArgs<Mutation>;
 
       return originalMutation(...([newArgs] as OptionalRestArgs<Mutation>));
@@ -170,23 +199,28 @@ export function useSessionMutation<
   );
 }
 
-// Like useAction, but for a Action that takes a session ID.
+/**
+ * Use this in place of {@link useAction} to run an action with a sessionId.
+ *
+ * It automatically injects the sessionId parameter.
+ * @param action Action that takes in a sessionId parameter. Like `api.foo.bar`.
+ * @param args Args for that action, without the sessionId.
+ * @returns An action result. For SSR, it will wait until the client has a
+ * valid sessionId.
+ */
 export function useSessionAction<Action extends SessionFunction<"action">>(
   name: Action
 ) {
-  const [sessionId] = useSessionId("ssr");
+  const [sessionId, _, sessionIdPromise] = useSessionId();
   const originalAction = useAction(name);
 
   return useCallback(
-    (
+    async (
       ...args: SessionArgsArray<Action>
     ): Promise<FunctionReturnType<Action>> => {
-      if (sessionId === undefined) {
-        throw new Error("useSessionMutation: Session ID is not available yet.");
-      }
       const newArgs = {
         ...(args[0] ?? {}),
-        sessionId,
+        sessionId: sessionId || (await sessionIdPromise),
       } as FunctionArgs<Action>;
 
       return originalAction(...([newArgs] as OptionalRestArgs<Action>));
@@ -196,36 +230,36 @@ export function useSessionAction<Action extends SessionFunction<"action">>(
 }
 
 /**
- * Get the session ID within the SessionProvider context and a refres function.
+ * Get the session context when nested under a SessionProvider.
  *
- * @param ssrFriendly - Set if you're using this with ssrFriendly. In these
- * cases, the session ID will be undefined on the first render.
- * @returns The current session ID and a function to refresh it.
- * Note: The session ID will only be undefined on the first render
- * when ssrFriendly is passed to SessionProvider.
+ * @returns [sessionId, refresh, sessionIdPromise] where:
+ * The `sessionId` will only be `undefined` when using SSR with `ssrFriendly`.
+ * during which time `sessionId` will be `undefined` for the first render.
+ * To use it in an async context at that time, you can await `sessionIdPromise`.
+ * `refresh` will generate a new sessionId. Pass a function to it to run before
+ * generating the new ID.
  */
-export function useSessionId<SSR extends "ssr" | undefined = undefined>(
-  ssrFriendly?: SSR
-): readonly [
-  SSR extends "ssr" ? SessionId | undefined : SessionId,
+export function useSessionId(): readonly [
+  SessionId | undefined,
   RefreshSessionFn,
+  Promise<SessionId>,
 ] {
   const ctx = useContext(SessionContext);
   if (ctx === null) {
     throw new Error("Missing a <SessionProvider> wrapping this code.");
   }
-  if (ssrFriendly !== "ssr" && ctx.ssrFriendly) {
-    throw new Error(
-      "When you use ssrFriendly with ConvexProvider, " +
-        "you need to pass 'ssr' to useSessionId."
-    );
-  }
   if (!ctx.ssrFriendly && ctx.sessionId === undefined) {
     throw new Error("Session ID invalid. Clear your storage?");
   }
-  return [ctx.sessionId!, ctx.refreshSessionId] as const;
+  return [ctx.sessionId!, ctx.refreshSessionId, ctx.sessionIdPromise] as const;
 }
 
+/**
+ * Compare with {@link useState}, but also persists the value in sessionStorage.
+ * @param key Key to use for sessionStorage.
+ * @param initialValue If there is no value in storage, use this.
+ * @returns The value and a function to update it.
+ */
 export function useSessionStorage(
   key: string,
   initialValue: SessionId | undefined


### PR DESCRIPTION
Changes behavior for SSR:
- The value will not be persisted until there's a valid ID.
- Queries will skip until there's a valid ID
- Mutations and actions will await a promise for the first valid ID.

Breaking change for non-SSR (types only):
- The type for `useSessionId` now is `SessionId | undefined`. The value will not be undefined except if `ssrFriendly` is used and it's the first render. It's safe to use `sessionId!` if you aren't setting `ssrFriendly`. After considering a different API for SSR, this seemed like the most composable option. h/t to @conradkoh for feedback