### PR TITLE
Actually propagate return value validator in customFunctions

### DIFF
--- a/packages/convex-helpers/publish.sh
+++ b/packages/convex-helpers/publish.sh
@@ -7,9 +7,9 @@ npm run lint
 npm run test
 npm run clean
 npm run build
-# pushd ../../tests >/dev/null
-# npm run test
-# popd >/dev/null
+pushd ../../tests >/dev/null
+npm run test
+popd >/dev/null
 git diff --exit-code || {
   echo "Uncommitted changes found. Commit or stash them before publishing."
   exit 1

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -158,6 +158,7 @@ export function customQuery<
           ...fn.args,
           ...inputArgs,
         },
+        returns: fn.returns,
         handler: async (ctx, allArgs: any) => {
           const { split, rest } = splitArgs(inputArgs, allArgs);
           const added = await inputMod(ctx, split);
@@ -176,6 +177,7 @@ export function customQuery<
     }
     const handler = fn.handler ?? fn;
     return query({
+      returns: fn.returns,
       handler: async (ctx, args: any) => {
         const { ctx: modCtx, args: modArgs } = await inputMod(ctx, args);
         return await handler({ ...ctx, ...modCtx }, { ...args, ...modArgs });
@@ -270,6 +272,7 @@ export function customMutation<
           ...fn.args,
           ...inputArgs,
         },
+        returns: fn.returns,
         handler: async (ctx, allArgs: any) => {
           const { split, rest } = splitArgs(inputArgs, allArgs);
           const added = await inputMod(ctx, split);
@@ -288,6 +291,7 @@ export function customMutation<
     }
     const handler = fn.handler ?? fn;
     return mutation({
+      returns: fn.returns,
       handler: async (ctx, args: any) => {
         const { ctx: modCtx, args: modArgs } = await inputMod(ctx, args);
         return await handler({ ...ctx, ...modCtx }, { ...args, ...modArgs });
@@ -386,6 +390,7 @@ export function customAction<
           ...fn.args,
           ...inputArgs,
         },
+        returns: fn.returns,
         handler: async (ctx, allArgs: any) => {
           const { split, rest } = splitArgs(inputArgs, allArgs);
           const added = await inputMod(ctx, split);
@@ -404,6 +409,7 @@ export function customAction<
     }
     const handler = fn.handler ?? fn;
     return action({
+      returns: fn.returns,
       handler: async (ctx, args: any) => {
         const { ctx: modCtx, args: modArgs } = await inputMod(ctx, args);
         return await handler({ ...ctx, ...modCtx }, { ...args, ...modArgs });


### PR DESCRIPTION
While I was respecting all the types, I wasn't actually forwarding the return value validator to the original function wrapper.