### PR TITLE
Fix type issues from npm 1.13

### DIFF
--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -487,6 +487,16 @@ type Expand<ObjectType extends Record<any, any>> =
       }
     : never;
 
+type ArgsForHandlerType<
+  OneOrZeroArgs extends [] | [Record<string, any>],
+  ModMadeArgs extends Record<string, any>,
+> =
+  ModMadeArgs extends Record<string, never>
+    ? OneOrZeroArgs
+    : OneOrZeroArgs extends [infer A]
+      ? [Expand<A & ModMadeArgs>]
+      : [ModMadeArgs];
+
 /**
  * A builder that customizes a Convex function, whether or not it validates
  * arguments. If the customization requires arguments, however, the resulting
@@ -501,8 +511,8 @@ export type CustomBuilder<
   Visibility extends FunctionVisibility,
 > = {
   <
-    ArgsValidator extends PropertyValidators | void,
-    ReturnsValidator extends GenericValidator | void,
+    ArgsValidator extends PropertyValidators | GenericValidator | void,
+    ReturnsValidator extends PropertyValidators | GenericValidator | void,
     ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> = any,
     OneOrZeroArgs extends
       ArgsArrayForOptionalValidator<ArgsValidator> = DefaultArgsForOptionalValidator<ArgsValidator>,
@@ -513,17 +523,13 @@ export type CustomBuilder<
           returns?: ReturnsValidator;
           handler: (
             ctx: Overwrite<InputCtx, ModCtx>,
-            ...args: OneOrZeroArgs extends [infer A]
-              ? [Expand<A & ModMadeArgs>]
-              : [ModMadeArgs]
+            ...args: ArgsForHandlerType<OneOrZeroArgs, ModMadeArgs>
           ) => ReturnValue;
         }
       | {
           (
             ctx: Overwrite<InputCtx, ModCtx>,
-            ...args: OneOrZeroArgs extends [infer A]
-              ? [Expand<A & ModMadeArgs>]
-              : [ModMadeArgs]
+            ...args: ArgsForHandlerType<OneOrZeroArgs, ModMadeArgs>
           ): ReturnValue;
         },
   ): Registration<

--- a/packages/convex-helpers/validators.ts
+++ b/packages/convex-helpers/validators.ts
@@ -1,7 +1,6 @@
 import {
   GenericValidator,
   PropertyValidators,
-  VLiteral,
   VOptional,
   VString,
   VUnion,
@@ -32,7 +31,11 @@ export const literals = <
   T extends V[],
 >(
   ...args: T
-): VUnion<T[number], { [Index in keyof T]: VLiteral<T[Index]> }> => {
+): VUnion<T[number], any> => {
+  // The `any` above is unfortunate, because then we cannot get proper types
+  // for `validator.members`, but without it, TypeScript seems to have a hard
+  // time inferring the TS type for the first parameter.
+
   return v.union(...args.map(v.literal)) as any;
 };
 

--- a/tests/convex/customFns.ts
+++ b/tests/convex/customFns.ts
@@ -103,6 +103,7 @@ const addCtxArg = customQuery(
     return { a: "hi" };
   }),
 );
+
 export const addC = addCtxArg({
   args: {},
   handler: async (ctx) => {
@@ -116,12 +117,21 @@ export const addCU = addCtxArg({
     return { ctxA: ctx.a }; // !!!
   },
 });
-// Unvalidated variant 2
 queryMatches(addCU, {}, { ctxA: "" });
+
+// Unvalidated variant 2
 export const addCU2 = addCtxArg(async (ctx) => {
   return { ctxA: ctx.a }; // !!!
 });
 queryMatches(addCU2, {}, { ctxA: "" });
+
+// Unvalidated with type annotation
+export const addCU3 = addCtxArg({
+  handler: async (ctx, args: { foo: number }) => {
+    return { ctxA: ctx.a }; // !!!
+  },
+});
+queryMatches(addCU3, { foo: 123 }, { ctxA: "" });
 
 export const addCtxWithExistingArg = addCtxArg({
   args: { b: v.string() },

--- a/tests/convex/schema.ts
+++ b/tests/convex/schema.ts
@@ -1,6 +1,5 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { migrationsTable } from "convex-helpers/server/migrations";
 import { tableExampleTables } from "./table";
 import { crudExampleTables } from "./crud";
 

--- a/tests/convex/validators.ts
+++ b/tests/convex/validators.ts
@@ -19,7 +19,8 @@ import {
   pretend,
 } from "convex-helpers/validators";
 import { internalQuery } from "./_generated/server";
-import { Infer, ObjectType } from "convex/values";
+import { Infer, ObjectType, v } from "convex/values";
+import { Equals, assert } from "convex-helpers/index";
 
 export const emailValidator = brandedString("email");
 export type Email = Infer<typeof emailValidator>;
@@ -63,5 +64,14 @@ export const echo = internalQuery({
   args: ExampleFields,
   handler: async (ctx, args) => {
     return args;
+  },
+});
+
+export const testLiterals = internalQuery({
+  args: {
+    foo: literals("bar", "baz"),
+  },
+  handler: async (ctx, args) => {
+    assert<Equals<typeof args.foo, "bar" | "baz">>;
   },
 });

--- a/tests/convex/zod.test.ts
+++ b/tests/convex/zod.test.ts
@@ -36,6 +36,7 @@ test("zod kitchen sink", async () => {
     any: [1, "2"],
     array: ["1", "2"],
     object: { a: "1", b: 2 },
+    objectWithOptional: { a: "1" },
     union: 1,
     discriminatedUnion: { kind: "a" as const, a: "1" },
     literal: "hi" as const,

--- a/tests/convex/zodFns.ts
+++ b/tests/convex/zodFns.ts
@@ -40,6 +40,7 @@ export const kitchenSinkValidator = {
   any: z.unknown(),
   array: z.array(z.string()),
   object: z.object({ a: z.string(), b: z.number() }),
+  objectWithOptional: z.object({ a: z.string(), b: z.number().optional() }),
   union: z.union([z.string(), z.number()]),
   discriminatedUnion: z.discriminatedUnion("kind", [
     z.object({ kind: z.literal("a"), a: z.string() }),


### PR DESCRIPTION
Fixes three issues:
* `myCustomFunciton({ handler: (ctx, args: { foo: string } => ... })` now compiles
* `zodToConvex(z.object({ foo: z.number().optional() }))` now yields `{ foo?: number | undefined }` instead of `{ foo: number | undefined }`
* `literals("bar", "baz")` when used in an argument validator gets its TS type inferred as `"bar" | "baz"` instead of `string`. This fix required adding an `any` and throwing out some type information, so we're still looking into a better patch.
