### PR TITLE
Move tests into packages/convex-helpers

### DIFF
--- a/packages/convex-helpers/react/cache/hooks.ts
+++ b/packages/convex-helpers/react/cache/hooks.ts
@@ -10,7 +10,7 @@ import {
   getFunctionName,
 } from "convex/server";
 import { useContext, useEffect, useState } from "react";
-import { ConvexQueryCacheContext } from "./provider.js";
+import { ConvexQueryCacheContext } from "./provider";
 import { convexToJson } from "convex/values";
 
 /**

--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -30,8 +30,8 @@ import type {
   OptionalRestArgs,
 } from "convex/server";
 import { useQuery, useMutation, useAction } from "convex/react";
-import type { SessionId } from "../server/sessions.js";
-import { EmptyObject, BetterOmit, assert, Equals } from "../index.js";
+import type { SessionId } from "../server/sessions";
+import { EmptyObject, BetterOmit, assert, Equals } from "../index";
 
 export type UseStorage<T> = (
   key: string,

--- a/packages/convex-helpers/server/customFunctions.test.ts
+++ b/packages/convex-helpers/server/customFunctions.test.ts
@@ -4,9 +4,9 @@ import {
   customCtx,
   customMutation,
   customQuery,
-} from "./customFunctions.js";
-import { wrapDatabaseWriter } from "./rowLevelSecurity.js";
-import { SessionId, vSessionId } from "./sessions.js";
+} from "./customFunctions";
+import { wrapDatabaseWriter } from "./rowLevelSecurity";
+import { SessionId, vSessionId } from "./sessions";
 import { convexTest } from "convex-test";
 import {
   anyApi,

--- a/packages/convex-helpers/server/index.ts
+++ b/packages/convex-helpers/server/index.ts
@@ -12,8 +12,8 @@ import {
   PaginationResult,
 } from "convex/server";
 import { GenericId, Infer, ObjectType, Validator, v } from "convex/values";
-import { Expand } from "convex-helpers";
-import { partial } from "convex-helpers/validators";
+import { Expand } from "../index";
+import { partial } from "../validators";
 
 /**
  * Define a table with system fields _id and _creationTime. This also returns

--- a/packages/convex-helpers/server/migrations.ts
+++ b/packages/convex-helpers/server/migrations.ts
@@ -41,8 +41,8 @@ import {
   TableNamesInDataModel,
 } from "convex/server";
 import { GenericId, ObjectType, v } from "convex/values";
-import { asyncMap, ErrorMessage } from "convex-helpers";
-import { pretendRequired } from "convex-helpers/validators";
+import { asyncMap, ErrorMessage } from "../index";
+import { pretendRequired } from "../validators";
 
 export const DEFAULT_BATCH_SIZE = 100;
 

--- a/packages/convex-helpers/server/relationships.ts
+++ b/packages/convex-helpers/server/relationships.ts
@@ -11,7 +11,7 @@ import {
   FieldPaths,
 } from "convex/server";
 import { GenericId } from "convex/values";
-import { asyncMap, nullThrows } from "convex-helpers";
+import { asyncMap, nullThrows } from "../index";
 
 /**
  * getAll returns a list of Documents (or null) for the `Id`s passed in.

--- a/packages/convex-helpers/server/retries.ts
+++ b/packages/convex-helpers/server/retries.ts
@@ -13,7 +13,7 @@ import {
   internalMutationGeneric,
 } from "convex/server";
 import { v, ObjectType } from "convex/values";
-import { omit } from "convex-helpers";
+import { omit } from "../index";
 
 const DEFAULTS = {
   waitBackoff: 100,

--- a/packages/convex-helpers/server/rowLevelSecurity.ts
+++ b/packages/convex-helpers/server/rowLevelSecurity.ts
@@ -14,7 +14,7 @@ import {
   WithoutSystemFields,
 } from "convex/server";
 import { GenericId } from "convex/values";
-import { filter } from "convex-helpers/server/filter";
+import { filter } from "./filter";
 
 type Rule<Ctx, D> = (ctx: Ctx, doc: D) => Promise<boolean>;
 

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -34,7 +34,7 @@ import {
   DefaultFunctionArgs,
   ArgsArrayToObject,
 } from "convex/server";
-import { Mod, NoOp, Registration, splitArgs } from "convex-helpers/server/customFunctions";
+import { Mod, NoOp, Registration, splitArgs } from "./customFunctions";
 
 export type ZodValidator = Record<string, z.ZodTypeAny>;
 

--- a/packages/convex-helpers/tsconfig.json
+++ b/packages/convex-helpers/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "force",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "NodeNext",                                /* Specify what module code is generated. */
+    "module": "ESNext",                                /* Specify what module code is generated. */
     "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "NodeNext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "Bundler",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/packages/convex-helpers/validators.ts
+++ b/packages/convex-helpers/validators.ts
@@ -7,7 +7,7 @@ import {
   Validator,
   v,
 } from "convex/values";
-import { Expand } from "./index.js";
+import { Expand } from "./index";
 
 /**
  * Helper for defining a union of literals more concisely.


### PR DESCRIPTION
gets rid of the tests/ directory in favor of inlining tests. requires some hacks for getting tests to load their own functions.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
