### PR TITLE
Cached use queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6598,7 +6598,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.51-alpha.0",
+      "version": "0.1.51-alpha.4",
       "license": "MIT",
       "peerDependencies": {
         "convex": "^1.13.0",

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -721,6 +721,7 @@ navigation changes, view changes, etc.
 
 Related files:
 
+- [cache.ts](./react/cache.ts) re-exports things so you can import from a single convenient location.
 - [provider.tsx](./react/cache/provider.tsx) contains `ConvexQueryCacheProvider`,
   a configurable cache provider you put in your react app's root.
 - [hooks.ts](./react/cache/hooks.ts) contains cache-enabled drop-in
@@ -731,9 +732,8 @@ inside `<ConvexProvider>` in your react component tree:
 
 ```jsx
 
-import { ConvexQueryCacheProvider } from "convex-helpers/react/cache/provider";
-
-//...
+import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
+// For Next.js, import from "convex-helpers/react/cache/provider"; instead
 
 export default function RootLayout({
   children,
@@ -766,9 +766,10 @@ Finally, you can utilize `useQuery` (and `useQueries`) just the same as
 their `convex/react` equivalents.
 
 ```jsx
-import { useQuery } from "convex-helpers/react/cache/hooks";
+import { useQuery } from "convex-helpers/react/cache";
+// For Next.js, import from "convex-helpers/react/cache/hooks"; instead
 
 // ...
 
-const users = useQuery(api.users.getAll);
+const users = useQuery(api.todos.getAll);
 ```

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -24,6 +24,10 @@
       "types": "./react.d.ts",
       "default": "./react.js"
     },
+    "./react/cache": {
+      "types": "./react/cache.d.ts",
+      "default": "./react/cache.js"
+    },
     "./react/sessions": {
       "types": "./react/sessions.d.ts",
       "default": "./react/sessions.js"

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.51-alpha.0",
+  "version": "0.1.51-alpha.4",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "exports": {

--- a/packages/convex-helpers/react/cache.ts
+++ b/packages/convex-helpers/react/cache.ts
@@ -1,0 +1,2 @@
+export { ConvexQueryCacheProvider } from "./cache/provider.js";
+export { useQuery, useQueries } from "./cache/hooks.js";

--- a/packages/convex-helpers/react/cache/hooks.ts
+++ b/packages/convex-helpers/react/cache/hooks.ts
@@ -2,6 +2,7 @@ import {
   ConvexProvider,
   OptionalRestArgsOrSkip,
   RequestForQueries,
+  useQueries as useQueriesCore,
 } from "convex/react";
 import {
   FunctionArgs,
@@ -9,7 +10,7 @@ import {
   FunctionReturnType,
   getFunctionName,
 } from "convex/server";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo } from "react";
 import { ConvexQueryCacheContext } from "./provider.js";
 import { convexToJson } from "convex/values";
 
@@ -76,28 +77,16 @@ export function useQueries(
     );
   }
   const queryKeys: Record<string, string> = {};
-  const results: Record<string, any | undefined | Error> = {};
   for (const [key, { query, args }] of Object.entries(queries)) {
-    const queryKey = createQueryKey(query, args);
-    results[key] = registry.probe(queryKey);
-    queryKeys[key] = queryKey;
+    queryKeys[key] = createQueryKey(query, args);
   }
-
-  const [_, setValues] =
-    useState<Record<string, any | undefined | Error>>(results);
 
   useEffect(
     () => {
       const ids: string[] = [];
       for (const [key, { query, args }] of Object.entries(queries)) {
         const id = crypto.randomUUID();
-        registry.start(id, queryKeys[key]!, query, args, (v) =>
-          setValues((old) => {
-            if (!(key in old)) return old; // We're no longer tracking this query
-            if (old[key] === v) return old; // No change
-            return { ...old, [key]: v };
-          }),
-        );
+        registry.start(id, queryKeys[key]!, query, args);
         ids.push(id);
       }
       return () => {
@@ -110,7 +99,8 @@ export function useQueries(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [registry, JSON.stringify(queryKeys)],
   );
-  return results;
+  const memoizedQueries = useMemo(() => queries, [JSON.stringify(queryKeys)]);
+  return useQueriesCore(memoizedQueries);
 }
 
 /**

--- a/packages/convex-helpers/react/cache/hooks.ts
+++ b/packages/convex-helpers/react/cache/hooks.ts
@@ -14,6 +14,17 @@ import { useContext, useEffect, useMemo } from "react";
 import { ConvexQueryCacheContext } from "./provider.js";
 import { convexToJson } from "convex/values";
 
+let uuid: () => string;
+try {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    uuid = crypto.randomUUID.bind(crypto);
+  }
+} catch (e) {
+  uuid = () =>
+    Math.random().toString(36).substring(2) +
+    Math.random().toString(36).substring(2);
+}
+
 /**
  * Load a variable number of reactive Convex queries, utilizing
  * the query cache.
@@ -85,7 +96,7 @@ export function useQueries(
     () => {
       const ids: string[] = [];
       for (const [key, { query, args }] of Object.entries(queries)) {
-        const id = crypto.randomUUID();
+        const id = uuid();
         registry.start(id, queryKeys[key]!, query, args);
         ids.push(id);
       }

--- a/publish.sh
+++ b/publish.sh
@@ -13,6 +13,10 @@ git diff --exit-code || {
   echo "Uncommitted changes found. Commit or stash them before publishing."
   exit 1
 }
+function cleanup() {
+  git co package-lock.json packages/convex-helpers/package.json
+}
+trap cleanup EXIT
 
 pushd packages/convex-helpers >/dev/null
 if [ "$1" == "alpha" ]; then
@@ -22,11 +26,6 @@ else
 fi
 current=$(npm pkg get version | tr -d '"')
 popd >/dev/null
-
-function cleanup() {
-  git co package-lock.json packages/convex-helpers/package.json
-}
-trap cleanup EXIT
 
 cat <<EOF
 Test it:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import SessionsExample from "./components/SessionsExample";
 import { HonoExample } from "./components/HonoExample";
 import { SessionProvider } from "convex-helpers/react/sessions";
 import { CacheExample } from "./components/CacheExample";
-import { ConvexQueryCacheProvider } from "convex-helpers/react/cache/provider";
+import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
 // Used for the session example if you want to store sessionId in local storage
 // import { useLocalStorage } from "usehooks-ts";
 
@@ -15,7 +15,11 @@ export default function App() {
       // storageKey={"ConvexSessionId"}
       // useStorage={useLocalStorage}
       >
-        <ConvexQueryCacheProvider maxIdleEntries={11} expiration={15000} debug={true}>
+        <ConvexQueryCacheProvider
+          maxIdleEntries={11}
+          expiration={15000}
+          debug={true}
+        >
           <Counter />
           <RelationshipExample />
           <SessionsExample />

--- a/src/components/CacheExample.tsx
+++ b/src/components/CacheExample.tsx
@@ -10,6 +10,7 @@ import { api } from "../../convex/_generated/api";
 export const CacheExample: FC = () => {
   const [count, setCount] = useState(4);
   const ref = useRef<HTMLInputElement>(null);
+  const [skip, setSkip] = useState(true);
   const children = [];
   const updateCount = () => {
     const r = parseInt(ref.current!.value);
@@ -21,7 +22,7 @@ export const CacheExample: FC = () => {
   for (let i = 0; i < count; i++) {
     children.push(<Added key={i} top={i + 1} />);
     if (count % 2 == 1) {
-      children.push(<Added key={i + count} top={i + 1} />);
+      children.push(<Added key={i + "extra"} top={i + 1} />);
     }
   }
   return (
@@ -35,22 +36,25 @@ export const CacheExample: FC = () => {
         onChange={updateCount}
       />
       <ul>{children}</ul>
-      <div>This is an element that skips on odd numbers:</div>
+      <div>This is an element that skips:</div>
       <div>
-        <Added top={count % 2 ? -1 : count} />
+        <button onClick={() => setSkip((skip) => !skip)}>
+          {skip ? "Unskip" : "Skip"}
+        </button>
+        <Added top={count % 2 ? -1 : count} skip={skip} />
       </div>
     </>
   );
 };
 
-const Added: FC<{ top: number }> = ({ top }) => {
-  const args = top === -1 ? "skip" : { top };
-  const sum = useQuery(api.addIt.addItUp, args);
+const Added: FC<{ top: number; skip?: boolean }> = ({ top, skip }) => {
+  const sum = useQuery(api.addIt.addItUp, skip ? "skip" : { top });
   if (sum === undefined) {
     // If you want to try the tanstack-style useQuery:
     // const { data: sum, isPending, error } = useQuery(api.addIt.addItUp, args);
     // if (error) throw error;
     // if (isPending) {
+    if (skip) return <li>Skipping...</li>;
     return <li>Loading {top}...</li>;
   } else {
     return (

--- a/src/components/CacheExample.tsx
+++ b/src/components/CacheExample.tsx
@@ -1,10 +1,10 @@
 import { FC, useRef, useState } from "react";
-import { useQuery } from "convex-helpers/react/cache/hooks";
+import { useQuery } from "convex-helpers/react/cache";
 import { api } from "../../convex/_generated/api";
 
 // Composing this with the tanstack-style useQuery:
 // import { makeUseQueryWithStatus } from "convex-helpers/react";
-// import { useQueries } from "convex-helpers/react/cache/hooks";
+// import { useQueries } from "convex-helpers/react/cache";
 // const useQuery= makeUseQueryWithStatus(useQueries);
 
 export const CacheExample: FC = () => {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Haven't tested it yet, but this would allow us to leverage cached `useQueries` without `useEffect`, enabling better server-side isomorphic opportunities. 

It essentially reduces the registry to a ref counter on subscriptions, vs. also being the source of truth for the value of the query

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
