### PR TITLE
Wildcard-export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6417,7 +6417,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.49",
+      "version": "0.1.50-alpha.0",
       "license": "MIT",
       "peerDependencies": {
         "convex": "^1.13.0",

--- a/packages/convex-helpers/generate-exports.mjs
+++ b/packages/convex-helpers/generate-exports.mjs
@@ -5,14 +5,25 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(new URL(import.meta.url)));
 
-const EntryPointFiles = [
-  "./index.ts",
-  "./testing.ts",
-  "./validators.ts",
-  "./react.ts",
-  "./server.ts",
-];
-const EntryPointDirectories = ["./react", "./react/cache", "./server"];
+function directoryContents(dirname) {
+  return fs
+    .readdirSync(path.join(__dirname, dirname))
+    .filter((filename) => filename.endsWith(".ts") || filename.endsWith(".tsx"))
+    .filter((filename) => !filename.includes(".test"))
+    .map((filename) => path.join(dirname, filename));
+}
+
+const EntryPointDirectories = ["react", "react/cache", "server"];
+function entryPointFiles() {
+  return [
+    "./index.ts",
+    "./testing.ts",
+    "./validators.ts",
+    "./server.ts",
+    "./react.ts",
+    ...EntryPointDirectories.map(directoryContents).flat(),
+  ];
+}
 
 function entryPointFromFile(source) {
   let entryPoint = path.join(path.parse(source).dir, path.parse(source).name);
@@ -42,13 +53,13 @@ function generateExport(source) {
 
 function generateExports() {
   const obj = {};
-  for (const entryPoint of EntryPointFiles) {
+  for (const entryPoint of entryPointFiles()) {
     obj[entryPointFromFile(entryPoint)] = generateExport(entryPoint);
   }
   for (const entryPointDir of EntryPointDirectories) {
-    obj[entryPointDir + "/*"] = {
-      types: entryPointDir + "/*.d.ts",
-      default: entryPointDir + "/*.js",
+    obj[`./${entryPointDir}/*`] = {
+      types: `./${entryPointDir}/*.d.ts`,
+      default: `./${entryPointDir}/*.js`,
     };
   }
   return obj;

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -17,68 +17,24 @@
       "default": "./validators.js"
     },
     "./react": {
-      "types": "./react/index.d.ts",
-      "default": "./react/index.js"
-    },
-    "./react/sessions": {
-      "types": "./react/sessions.d.ts",
-      "default": "./react/sessions.js"
-    },
-    "./react/cache/hooks": {
-      "types": "./react/cache/hooks.d.ts",
-      "default": "./react/cache/hooks.js"
-    },
-    "./react/cache/provider": {
-      "types": "./react/cache/provider.d.ts",
-      "default": "./react/cache/provider.js"
-    },
-    "./server/customFunctions": {
-      "types": "./server/customFunctions.d.ts",
-      "default": "./server/customFunctions.js"
-    },
-    "./server/filter": {
-      "types": "./server/filter.d.ts",
-      "default": "./server/filter.js"
-    },
-    "./server/hono": {
-      "types": "./server/hono.d.ts",
-      "default": "./server/hono.js"
+      "types": "./react.d.ts",
+      "default": "./react.js"
     },
     "./server": {
-      "types": "./server/index.d.ts",
-      "default": "./server/index.js"
+      "types": "./server.d.ts",
+      "default": "./server.js"
     },
-    "./server/migrations": {
-      "types": "./server/migrations.d.ts",
-      "default": "./server/migrations.js"
+    "./react/*": {
+      "types": "./react/*.d.ts",
+      "default": "./react/*.js"
     },
-    "./server/pagination": {
-      "types": "./server/pagination.d.ts",
-      "default": "./server/pagination.js"
+    "./react/cache/*": {
+      "types": "./react/cache/*.d.ts",
+      "default": "./react/cache/*.js"
     },
-    "./server/rateLimit": {
-      "types": "./server/rateLimit.d.ts",
-      "default": "./server/rateLimit.js"
-    },
-    "./server/relationships": {
-      "types": "./server/relationships.d.ts",
-      "default": "./server/relationships.js"
-    },
-    "./server/retries": {
-      "types": "./server/retries.d.ts",
-      "default": "./server/retries.js"
-    },
-    "./server/rowLevelSecurity": {
-      "types": "./server/rowLevelSecurity.d.ts",
-      "default": "./server/rowLevelSecurity.js"
-    },
-    "./server/sessions": {
-      "types": "./server/sessions.d.ts",
-      "default": "./server/sessions.js"
-    },
-    "./server/zod": {
-      "types": "./server/zod.d.ts",
-      "default": "./server/zod.js"
+    "./server/*": {
+      "types": "./server/*.d.ts",
+      "default": "./server/*.js"
     }
   },
   "repository": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.49",
+  "version": "0.1.50-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "exports": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -16,13 +16,69 @@
       "types": "./validators.d.ts",
       "default": "./validators.js"
     },
+    "./server": {
+      "types": "./server.d.ts",
+      "default": "./server.js"
+    },
     "./react": {
       "types": "./react.d.ts",
       "default": "./react.js"
     },
-    "./server": {
-      "types": "./server.d.ts",
-      "default": "./server.js"
+    "./react/sessions": {
+      "types": "./react/sessions.d.ts",
+      "default": "./react/sessions.js"
+    },
+    "./react/cache/hooks": {
+      "types": "./react/cache/hooks.d.ts",
+      "default": "./react/cache/hooks.js"
+    },
+    "./react/cache/provider": {
+      "types": "./react/cache/provider.d.ts",
+      "default": "./react/cache/provider.js"
+    },
+    "./server/customFunctions": {
+      "types": "./server/customFunctions.d.ts",
+      "default": "./server/customFunctions.js"
+    },
+    "./server/filter": {
+      "types": "./server/filter.d.ts",
+      "default": "./server/filter.js"
+    },
+    "./server/hono": {
+      "types": "./server/hono.d.ts",
+      "default": "./server/hono.js"
+    },
+    "./server/migrations": {
+      "types": "./server/migrations.d.ts",
+      "default": "./server/migrations.js"
+    },
+    "./server/pagination": {
+      "types": "./server/pagination.d.ts",
+      "default": "./server/pagination.js"
+    },
+    "./server/rateLimit": {
+      "types": "./server/rateLimit.d.ts",
+      "default": "./server/rateLimit.js"
+    },
+    "./server/relationships": {
+      "types": "./server/relationships.d.ts",
+      "default": "./server/relationships.js"
+    },
+    "./server/retries": {
+      "types": "./server/retries.d.ts",
+      "default": "./server/retries.js"
+    },
+    "./server/rowLevelSecurity": {
+      "types": "./server/rowLevelSecurity.d.ts",
+      "default": "./server/rowLevelSecurity.js"
+    },
+    "./server/sessions": {
+      "types": "./server/sessions.d.ts",
+      "default": "./server/sessions.js"
+    },
+    "./server/zod": {
+      "types": "./server/zod.d.ts",
+      "default": "./server/zod.js"
     },
     "./react/*": {
       "types": "./react/*.d.ts",

--- a/packages/convex-helpers/react.ts
+++ b/packages/convex-helpers/react.ts
@@ -9,7 +9,7 @@ import {
   getFunctionName,
 } from "convex/server";
 import { useMemo } from "react";
-import { EmptyObject } from "../index.js";
+import { EmptyObject } from "./index.js";
 
 /**
  * Use in place of `useQuery` from "convex/react" to fetch data from a query

--- a/packages/convex-helpers/server.ts
+++ b/packages/convex-helpers/server.ts
@@ -12,8 +12,8 @@ import {
   PaginationResult,
 } from "convex/server";
 import { GenericId, Infer, ObjectType, Validator, v } from "convex/values";
-import { Expand } from "../index.js";
-import { partial } from "../validators.js";
+import { Expand } from "./index.js";
+import { partial } from "./validators.js";
 
 /**
  * Define a table with system fields _id and _creationTime. This also returns

--- a/publish.sh
+++ b/publish.sh
@@ -6,6 +6,7 @@ rm -rf packages/convex-helpers/node_modules
 npm i
 npm run clean
 npm run build
+npm i
 npm run lint
 npm run test
 git diff --exit-code || {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add wildcard exports to package to enable VSCode autocomplete for the library.
In addition to the explicit enumeration, so that we can still use arethetypeswrong.
involves moving *.index.ts files into *.ts files

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
