### PR TITLE
fix uuid assignment

### DIFF
--- a/packages/convex-helpers/react/cache/hooks.ts
+++ b/packages/convex-helpers/react/cache/hooks.ts
@@ -14,16 +14,20 @@ import { useContext, useEffect, useMemo } from "react";
 import { ConvexQueryCacheContext } from "./provider.js";
 import { convexToJson } from "convex/values";
 
+const simpleUuid = () =>
+    Math.random().toString(36).substring(2) +
+    Math.random().toString(36).substring(2);
 let uuid: () => string;
 try {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
     uuid = crypto.randomUUID.bind(crypto);
+  } else {
+    uuid = simpleUuid;
   }
 } catch (e) {
-  uuid = () =>
-    Math.random().toString(36).substring(2) +
-    Math.random().toString(36).substring(2);
+  uuid = simpleUuid;
 }
+
 
 /**
  * Load a variable number of reactive Convex queries, utilizing


### PR DESCRIPTION
<!-- Describe your PR here. -->

Problem: If `crypto` is undefined, `uuid` remains undefined.

This solution: Ensures the ad hoc uuid function is assigned whether binding to `crypto.randomUUID` throws or not.

Tested and working in React Native (where `crypto` is undefined).


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
