### PR TITLE
Add CLI binary within package that we ship

### DIFF
--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.53-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
+  "bin": "./dist/bin.cjs",
   "exports": {
     ".": {
       "types": "./index.d.ts",
@@ -98,7 +99,8 @@
     }
   },
   "scripts": {
-    "build": "node generate-exports.mjs && mkdir -p dist && cp -r *.ts server react ./package.json ./tsconfig.json ./README.md ../../LICENSE ./.npmignore dist/ && rm dist/server/_generated/_ignore.ts && cd dist/ && tsc",
+    "build:bin": "esbuild ../../cli/index.ts --bundle --platform=node --external:prettier --format=cjs --outfile=dist/bin.cjs",
+    "build": "node generate-exports.mjs && mkdir -p dist && npm run build:bin && cp -r *.ts server react ./package.json ./tsconfig.json ./README.md ../../LICENSE ./.npmignore dist/ && rm dist/server/_generated/_ignore.ts && cd dist/ && tsc",
     "dev": "chokidar '*.ts' 'server/**/*.ts' 'react/**/*.ts*' 'tsconfig*.json' 'package.json' -c 'cd ../.. && npm run build' --initial"
   },
   "repository": {


### PR DESCRIPTION
Previously, the binary was only included in the top-level directory and not in the package that is shipped.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
