### PR TITLE
Move bin from `./dist/bin.cjs` -> `./bin.cjs`

### DIFF
--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {
-    "convex-helpers": "./dist/bin.cjs"
+    "convex-helpers": "./bin.cjs"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
We only copy the `dist` package when publishing, so all paths need to be relative to the `/dist` folder.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
