### PR TITLE
Refactor HttpRouterWithHono to handle empty handlersAndRoutes array

### DIFF
--- a/packages/convex-helpers/server/hono.ts
+++ b/packages/convex-helpers/server/hono.ts
@@ -159,6 +159,11 @@ export class HttpRouterWithHono<
     // There might be multiple handlers for a route (in the case of middleware),
     // so choose the most specific one for the purposes of logging
     const handlersAndRoutes = match[0];
+
+    if (!handlersAndRoutes?.length) {
+      return [this._handler, normalizeMethod(method), path] as const;
+    }
+    
     const mostSpecificHandler =
       handlersAndRoutes[handlersAndRoutes.length - 1]![0][0];
     // On the first request let's populate a lookup from handler to info


### PR DESCRIPTION
<!-- Describe your PR here. -->
Implements a fix allowing the Hono 404 route to trigger, preventing an error from being returned.
[discord](https://discord.com/channels/1019350475847499849/1283924028012363877) 
<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
