### PR TITLE
Change triggers API to work alongside `customCtx`

### DIFF
--- a/convex/triggersExample.ts
+++ b/convex/triggersExample.ts
@@ -61,13 +61,10 @@ triggers.register("counter_table", async (ctx, change) => {
   }
 });
 
-const mutation = customMutation(
-  rawMutation,
-  customCtx((ctx) => ({ db: triggers.dbWrapper(ctx) })),
-);
-const internalMutation = customMutation(
+export const mutation = customMutation(rawMutation, customCtx(triggers.wrapDB));
+export const internalMutation = customMutation(
   rawInternalMutation,
-  customCtx((ctx) => ({ db: triggers.dbWrapper(ctx) })),
+  customCtx(triggers.wrapDB),
 );
 
 export const getCounters = query({
@@ -126,8 +123,7 @@ const mutationWithRLS = customMutation(
   rawMutation,
   customCtx(async (ctx) => {
     const viewer = (await ctx.auth.getUserIdentity())?.tokenIdentifier ?? null;
-    const db = triggersWithRLS.dbWrapper({ ...ctx, viewer });
-    return { viewer, db };
+    return triggersWithRLS.wrapDB({ ...ctx, viewer });
   }),
 );
 

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -878,6 +878,7 @@ Convex mutation defined. Here's an example of using triggers to do four things:
 import { mutation as rawMutation } from "./_generated/server";
 import { DataModel } from "./_generated/dataModel";
 import { Triggers } from "convex-helpers/server/triggers";
+import { customCtx, customMutation } from "convex-helpers/server/customFunctions";
 
 const triggers = new Triggers<DataModel>();
 
@@ -933,7 +934,10 @@ triggers.register("users", async (ctx, change) => {
 });
 
 // Use `mutation` to define all mutations, and the triggers will get called.
-export const mutation = customMutation(rawMutation, triggers.customFunctionWrapper());
+export const mutation = customMutation(
+  rawMutation,
+  customCtx((ctx) => ({ db: triggers.dbWrapper(ctx) })),
+);
 ```
 
 Now that you have redefined `mutation`, add an
@@ -966,7 +970,7 @@ forbid using the raw mutation wrappers which don't call your triggers.
 
 - The `change` argument tells you exactly how the document changed via a single
   `ctx.db.insert`, `ctx.db.patch`, `ctx.db.replace`, or `ctx.db.delete`.
-  If these functions are called in parallel with `Promise.all`, they will be 
+  If these functions are called in parallel with `Promise.all`, they will be
   serialized as if they happened sequentially.
 - A database write is executed atomically with all of its triggers, so you can
   update a denormalized field in a trigger without worrying about parallel

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -934,10 +934,7 @@ triggers.register("users", async (ctx, change) => {
 });
 
 // Use `mutation` to define all mutations, and the triggers will get called.
-export const mutation = customMutation(
-  rawMutation,
-  customCtx((ctx) => ({ db: triggers.dbWrapper(ctx) })),
-);
+export const mutation = customMutation(rawMutation, customCtx(triggers.wrapDB));
 ```
 
 Now that you have redefined `mutation`, add an

--- a/packages/convex-helpers/server/triggers.test.ts
+++ b/packages/convex-helpers/server/triggers.test.ts
@@ -35,10 +35,7 @@ triggers.register("users", async (ctx, change) => {
   }
 });
 
-export const mutation = customMutation(
-  rawMutation,
-  customCtx((ctx) => ({ db: triggers.dbWrapper(ctx) })),
-);
+const mutation = customMutation(rawMutation, customCtx(triggers.wrapDB));
 
 export const createUser = mutation({
   args: { firstName: v.string(), lastName: v.string() },

--- a/packages/convex-helpers/server/triggers.test.ts
+++ b/packages/convex-helpers/server/triggers.test.ts
@@ -1,6 +1,4 @@
-import {
-  customMutation,
-} from "./customFunctions.js";
+import { customCtx, customMutation } from "./customFunctions.js";
 import { Triggers } from "./triggers.js";
 import { convexTest } from "convex-test";
 import {
@@ -37,7 +35,10 @@ triggers.register("users", async (ctx, change) => {
   }
 });
 
-const mutation = customMutation(rawMutation, triggers.customFunctionWrapper());
+export const mutation = customMutation(
+  rawMutation,
+  customCtx((ctx) => ({ db: triggers.dbWrapper(ctx) })),
+);
 
 export const createUser = mutation({
   args: { firstName: v.string(), lastName: v.string() },
@@ -47,7 +48,7 @@ export const createUser = mutation({
       lastName: args.lastName,
       fullName: "",
     });
-  }
+  },
 });
 
 const testApi: ApiFromModules<{

--- a/packages/convex-helpers/server/triggers.ts
+++ b/packages/convex-helpers/server/triggers.ts
@@ -46,11 +46,9 @@ export type Change<
  * triggers.register("myTableName", async (ctx, change) => {
  *   console.log("Table changed", change);
  * });
+ *
  * // Use `mutation` to define all mutations, and the triggers will get called.
- * export const mutation = customMutation(
- *   rawMutation,
- *   customCtx(ctx => ({ db: triggers.dbWrapper(ctx) })),
- * );
+ * export const mutation = customMutation(rawMutation, customCtx(triggers.wrapDB));
  * ```
  */
 export class Triggers<
@@ -71,9 +69,9 @@ export class Triggers<
     this.registered[tableName]!.push(trigger);
   }
 
-  dbWrapper(ctx: Ctx): GenericDatabaseWriter<DataModel> {
-    return new DatabaseWriterWithTriggers(ctx, ctx.db, this);
-  }
+  wrapDB = (ctx: Ctx): Ctx => {
+    return { ...ctx, db: new DatabaseWriterWithTriggers(ctx, ctx.db, this) };
+  };
 }
 
 class Lock {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Instead of wrapping the whole custom function and needing to use its nuanced interface to extend, let's just get them using `customCtx` from day one. My prettier config breaks it into multiple lines anyways, so it wouldn't have been a one-liner either way.

I have prettier changes that I omitted for this PR. Not sure if I'm running something different or if you aren't running it


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
