### PR TITLE
Ian/z record

### DIFF
--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.62",
+  "version": "0.1.63-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/server/zod.test.ts
+++ b/packages/convex-helpers/server/zod.test.ts
@@ -37,6 +37,10 @@ export const kitchenSinkValidator = {
   array: z.array(z.string()),
   object: z.object({ a: z.string(), b: z.number() }),
   objectWithOptional: z.object({ a: z.string(), b: z.number().optional() }),
+  record: z.record(
+    z.union([z.string(), zid("users")]),
+    z.union([z.number(), z.string()]),
+  ),
   union: z.union([z.string(), z.number()]),
   discriminatedUnion: z.discriminatedUnion("kind", [
     z.object({ kind: z.literal("a"), a: z.string() }),
@@ -303,6 +307,7 @@ test("zod kitchen sink", async () => {
     array: ["1", "2"],
     object: { a: "1", b: 2 },
     objectWithOptional: { a: "1" },
+    record: { a: 1 },
     union: 1,
     discriminatedUnion: { kind: "a" as const, a: "1" },
     literal: "hi" as const,
@@ -397,6 +402,16 @@ test("zod kitchen sink", async () => {
         },
         optional: false,
       },
+      objectWithOptional: {
+        fieldType: {
+          type: "object",
+          value: {
+            a: { fieldType: { type: "string" }, optional: false },
+            b: { fieldType: { type: "number" }, optional: true },
+          },
+        },
+        optional: false,
+      },
       optional: {
         fieldType: {
           type: "object",
@@ -417,6 +432,21 @@ test("zod kitchen sink", async () => {
           },
         },
         optional: false,
+      },
+      record: {
+        fieldType: {
+          keys: {
+            type: "union",
+            value: [{ type: "string" }, { tableName: "users", type: "id" }],
+          },
+          type: "record",
+          values: {
+            fieldType: {
+              type: "union",
+              value: [{ type: "number" }, { type: "string" }],
+            },
+          },
+        },
       },
       tuple: {
         fieldType: {
@@ -535,6 +565,7 @@ assert(
       nan: z.nan(),
       optional: z.number().optional(),
       optional2: z.optional(z.number()),
+      record: z.record(z.string(), z.number()),
       default: z.number().default(0),
       nullable: z.number().nullable(),
       null: z.null(),
@@ -549,6 +580,7 @@ assert(
       nan: v.number(),
       optional: v.optional(v.number()),
       optional2: v.optional(v.number()),
+      record: v.record(v.string(), v.number()),
       default: v.optional(v.number()),
       nullable: v.union(v.number(), v.null()),
       null: v.null(),

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -20,6 +20,7 @@ import {
   VOptional,
   VObject,
   Validator,
+  VRecord,
 } from "convex/values";
 import {
   FunctionVisibility,
@@ -583,36 +584,66 @@ type ConvexValidatorFromZod<Z extends z.ZodTypeAny> =
                                                     ConvexValidatorFromZod<Inner>
                                                   >
                                                 : never
-                                              : Z extends z.ZodReadonly<
-                                                    infer Inner
+                                              : Z extends z.ZodRecord<
+                                                    infer K,
+                                                    infer V
                                                   >
-                                                ? ConvexValidatorFromZod<Inner>
-                                                : Z extends z.ZodPipeline<
-                                                      infer Inner,
-                                                      any
-                                                    > // Validate input type
+                                                ? K extends
+                                                    | z.ZodString
+                                                    | Zid<string>
+                                                    | z.ZodUnion<
+                                                        [
+                                                          (
+                                                            | z.ZodString
+                                                            | Zid<string>
+                                                          ),
+                                                          (
+                                                            | z.ZodString
+                                                            | Zid<string>
+                                                          ),
+                                                          ...(
+                                                            | z.ZodString
+                                                            | Zid<string>
+                                                          )[],
+                                                        ]
+                                                      >
+                                                  ? VRecord<
+                                                      z.RecordType<
+                                                        ConvexValidatorFromZod<K>["type"],
+                                                        ConvexValidatorFromZod<V>["type"]
+                                                      >,
+                                                      ConvexValidatorFromZod<K>,
+                                                      ConvexValidatorFromZod<V>
+                                                    >
+                                                  : never
+                                                : Z extends z.ZodReadonly<
+                                                      infer Inner
+                                                    >
                                                   ? ConvexValidatorFromZod<Inner>
-                                                  : // Some that are a bit unknown
-                                                    // : Z extends z.ZodDate ? Validator<number>
-                                                    // : Z extends z.ZodSymbol ? Validator<symbol>
-                                                    // : Z extends z.ZodNever ? Validator<never>
-                                                    // : Z extends z.ZodIntersection<infer T, infer U>
-                                                    // ? Validator<
-                                                    //     ConvexValidatorFromZodValidator<T>["type"] &
-                                                    //       ConvexValidatorFromZodValidator<U>["type"],
-                                                    //     "required",
-                                                    //     ConvexValidatorFromZodValidator<T>["fieldPaths"] |
-                                                    //       ConvexValidatorFromZodValidator<U>["fieldPaths"]
-                                                    //   >
-                                                    // Is arraybuffer a thing?
-                                                    // Z extends z.??? ? Validator<ArrayBuffer> :
-                                                    // If/when Convex supports Record:
-                                                    // Z extends z.ZodRecord<infer K, infer V> ? RecordValidator<ConvexValidatorFromZodValidator<K>["type"], ConvexValidatorFromZodValidator<V>["type"]> :
-                                                    // Note: we don't handle z.undefined() in union, nullable, etc.
-                                                    // ? Validator<any, "required", string>
-                                                    // We avoid doing this catch-all to avoid over-promising on types
-                                                    // : Z extends z.ZodTypeAny
-                                                    never;
+                                                  : Z extends z.ZodPipeline<
+                                                        infer Inner,
+                                                        any
+                                                      > // Validate input type
+                                                    ? ConvexValidatorFromZod<Inner>
+                                                    : // Some that are a bit unknown
+                                                      // : Z extends z.ZodDate ? Validator<number>
+                                                      // : Z extends z.ZodSymbol ? Validator<symbol>
+                                                      // : Z extends z.ZodNever ? Validator<never>
+                                                      // : Z extends z.ZodIntersection<infer T, infer U>
+                                                      // ? Validator<
+                                                      //     ConvexValidatorFromZod<T>["type"] &
+                                                      //       ConvexValidatorFromZod<U>["type"],
+                                                      //     "required",
+                                                      //     ConvexValidatorFromZod<T>["fieldPaths"] |
+                                                      //       ConvexValidatorFromZod<U>["fieldPaths"]
+                                                      //   >
+                                                      // Is arraybuffer a thing?
+                                                      // Z extends z.??? ? Validator<ArrayBuffer> :
+                                                      // Note: we don't handle z.undefined() in union, nullable, etc.
+                                                      // ? Validator<any, "required", string>
+                                                      // We avoid doing this catch-all to avoid over-promising on types
+                                                      // : Z extends z.ZodTypeAny
+                                                      never;
 
 /**
  * Turn a Zod validator into a Convex Validator.
@@ -700,6 +731,22 @@ export function zodToConvex<Z extends z.ZodTypeAny>(
         return withDefault as ConvexValidatorFromZod<Z>;
       }
       return v.optional(withDefault) as ConvexValidatorFromZod<Z>;
+    case "ZodRecord":
+      const keyType = zodToConvex(
+        zod._def.keyType,
+      ) as ConvexValidatorFromZod<Z>;
+      function ensureStringOrId(v: GenericValidator) {
+        if (v.kind === "union") {
+          v.members.map(ensureStringOrId);
+        } else if (v.kind !== "string" && v.kind !== "id") {
+          throw new Error("Record keys must be strings or ids: " + v.kind);
+        }
+      }
+      ensureStringOrId(keyType);
+      return v.record(
+        keyType,
+        zodToConvex(zod._def.valueType) as ConvexValidatorFromZod<Z>,
+      ) as unknown as ConvexValidatorFromZod<Z>;
     case "ZodReadonly":
       return zodToConvex(zod._def.innerType) as ConvexValidatorFromZod<Z>;
     case "ZodPipeline":
@@ -713,7 +760,6 @@ export function zodToConvex<Z extends z.ZodTypeAny>(
     // case "ZodNever":
     // case "ZodVoid":
     // case "ZodIntersection":
-    // case "ZodRecord":
     // case "ZodMap":
     // case "ZodSet":
     // case "ZodFunction":


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adds support for z.record mapping to v.record.

Only works for keys that are strings / Ids

fixes #324 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
