### PR TITLE
fix getAll to bind db

### DIFF
--- a/packages/convex-helpers/server/relationships.ts
+++ b/packages/convex-helpers/server/relationships.ts
@@ -48,7 +48,7 @@ export async function getAll<
   db: GenericDatabaseReader<DataModel>,
   ids: Iterable<GenericId<TableName>> | Promise<Iterable<GenericId<TableName>>>,
 ): Promise<(DocumentByName<DataModel, TableName> | null)[]> {
-  return asyncMap(ids, db.get);
+  return asyncMap(ids, (id) => db.get(id));
 }
 
 /**


### PR DESCRIPTION
<!-- Describe your PR here. -->

fixes `getAll` so it works with stateful `db` implementations, like `WrapWriter` as used by `wrapDatabaseWriter` for RLS.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
