### PR TITLE
fix types with new convex version

### DIFF
--- a/packages/convex-helpers/server/hono.ts
+++ b/packages/convex-helpers/server/hono.ts
@@ -104,12 +104,15 @@ export class HttpRouterWithHono<
    * @returns - an array of [path, method, endpoint] tuples.
    */
   override getRoutes = () => {
-    const convexRoutes: [string, RoutableMethod, (...args: any) => any][] = [];
+    const convexRoutes: [string, RoutableMethod, PublicHttpAction][] = [];
 
     // Likely a better way to do this, but hono will have multiple handlers with the same
     // name (i.e. for middleware), so de-duplicate so we don't show multiple routes in the dashboard.
     const seen = new Set();
     this._app.routes.forEach((route) => {
+      const handler: PublicHttpAction = route.handler as any;
+      handler.isHttp = true;
+
       // Hono uses "ALL" in its router, which is not supported by the Convex router.
       // Expand this into a route for every routable method supported by Convex.
       if (route.method === "ALL") {
@@ -117,7 +120,7 @@ export class HttpRouterWithHono<
           const name = `${method} ${route.path}`;
           if (!seen.has(name)) {
             seen.add(name);
-            convexRoutes.push([route.path, method, route.handler]);
+            convexRoutes.push([route.path, method, handler]);
           }
         }
       } else {
@@ -127,7 +130,7 @@ export class HttpRouterWithHono<
           convexRoutes.push([
             route.path,
             route.method as RoutableMethod,
-            route.handler,
+            handler,
           ]);
         }
       }

--- a/packages/convex-helpers/server/hono.ts
+++ b/packages/convex-helpers/server/hono.ts
@@ -110,7 +110,9 @@ export class HttpRouterWithHono<
     // name (i.e. for middleware), so de-duplicate so we don't show multiple routes in the dashboard.
     const seen = new Set();
     this._app.routes.forEach((route) => {
-      const handler: PublicHttpAction = route.handler as any;
+      // The (internal) field _handler on PublicHttpAction is used to look up the function's line number.
+      const handler = route.handler as any;
+      handler._handler = route.handler;
       handler.isHttp = true;
 
       // Hono uses "ALL" in its router, which is not supported by the Convex router.


### PR DESCRIPTION
<!-- Describe your PR here. -->

whoops I changed the types in https://github.com/get-convex/convex-backend/commit/064d9d387b9d0848d4992874cd03792b9ed91646 (because `httpAction(...)` should not be callable as if it were a plain js function).

Didn't realize the type was used by HonoWithConvex.
We can fix it like this PR does, by changing the types of HonoWithConvex to use PublicHttpAction.

An alternative might be for `getRoutes` to directly return the function which has the line numbers that you want.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
