### PR TITLE
await expected failures in tests

### DIFF
--- a/packages/convex-helpers/server/customFunctions.test.ts
+++ b/packages/convex-helpers/server/customFunctions.test.ts
@@ -388,10 +388,10 @@ test("custom function with user auth", async () => {
   const authed = t.withIdentity({ tokenIdentifier: "foo" });
 
   // Make sure the custom function is protected by auth.
-  expect(() => t.query(testApi.getSomething, { foo: "foo" })).rejects.toThrow(
+  await expect(() => t.query(testApi.getSomething, { foo: "foo" })).rejects.toThrow(
     "Unauthenticated",
   );
-  expect(() =>
+  await expect(() =>
     t
       .withIdentity({ tokenIdentifier: "bar" })
       .query(testApi.getSomething, { foo: "foo" }),
@@ -407,13 +407,13 @@ test("custom function with user auth", async () => {
     tokenIdentifier: "foo",
     sessionId: "bar" as SessionId,
   });
-  expect(() =>
+  await expect(() =>
     authed.mutation(testApi.create, {
       tokenIdentifier: "bar",
       sessionId: "bar" as SessionId,
     }),
   ).rejects.toThrow("insert access not allowed");
-  expect(() =>
+  await expect(() =>
     authed.mutation(testApi.create, {
       tokenIdentifier: "bar",
       sessionId: "" as SessionId,
@@ -436,7 +436,7 @@ describe("custom functions with api auth", () => {
       apiKey,
       tokenIdentifier: "bar",
     });
-    expect(() =>
+    await expect(() =>
       t.mutation(testApi.fnCalledFromMyBackend, {
         apiKey: "",
         tokenIdentifier: "bar",
@@ -524,7 +524,7 @@ describe("custom functions", () => {
 
   test("still validates args", async () => {
     const t = convexTest(schema, modules);
-    expect(() => t.query(testApi.redefine, { a: 3 as any })).rejects.toThrow(
+    await expect(() => t.query(testApi.redefine, { a: 3 as any })).rejects.toThrow(
       "Validator error: Expected `string`",
     );
   });
@@ -553,7 +553,7 @@ describe("nested custom functions", () => {
 
   test("still validates args", async () => {
     const t = convexTest(schema, modules);
-    expect(() =>
+    await expect(() =>
       t.query(testApi.outerAdds, { a: 3 as any, outer: "" }),
     ).rejects.toThrow("Validator error: Expected `string`");
   });

--- a/packages/convex-helpers/server/rateLimit.test.ts
+++ b/packages/convex-helpers/server/rateLimit.test.ts
@@ -82,7 +82,7 @@ describe.each(["token bucket", "fixed window"] as const)(
 
     test("consume too much", async () => {
       const t = convexTest(schema, modules);
-      expect(() =>
+      await expect(() =>
         t.run(async (ctx) => {
           await rateLimit(ctx, {
             name: "simple",
@@ -220,7 +220,7 @@ describe.each(["token bucket", "fixed window"] as const)(
 
     test("consume too much reserved", async () => {
       const t = convexTest(schema, modules);
-      expect(() =>
+      await expect(() =>
         t.run(async (ctx) => {
           await rateLimit(ctx, {
             name: "simple",
@@ -242,7 +242,7 @@ describe.each(["token bucket", "fixed window"] as const)(
       const { rateLimit } = defineRateLimits({
         simple: { kind, rate: 1, period: Second },
       });
-      expect(() =>
+      await expect(() =>
         t.run(async (ctx) => {
           await rateLimit(ctx, { name: "simple" });
           await rateLimit(ctx, { name: "simple", throws: true });

--- a/packages/convex-helpers/server/rowLevelSecurity.test.ts
+++ b/packages/convex-helpers/server/rowLevelSecurity.test.ts
@@ -87,7 +87,7 @@ describe("row level security", () => {
     });
     const asA = t.withIdentity({ tokenIdentifier: "Person A" });
     const asB = t.withIdentity({ tokenIdentifier: "Person B" });
-    expect(() =>
+    await expect(() =>
       asB.run(async (ctx) => {
         const rls = await withRLS(ctx);
         return rls.db.delete(noteId);

--- a/packages/convex-helpers/server/validators.test.ts
+++ b/packages/convex-helpers/server/validators.test.ts
@@ -153,18 +153,18 @@ test("validators allow things when they're unset", async () => {
 
 test("validators disallow things when they're wrong", async () => {
   const t = convexTest(schema, modules);
-  expect(async () => {
+  await expect(async () => {
     await t.query(testApi.echo, {} as ExampleFields);
   }).rejects.toThrowError("Validator error");
   // extra field
-  expect(async () => {
+  await expect(async () => {
     await t.query(testApi.echo, {
       ...valid,
       unknown: 3,
     } as ExampleFields);
   }).rejects.toThrowError("Validator error");
   // pretend required shouldn't allow other types
-  expect(async () => {
+  await expect(async () => {
     await t.query(testApi.echo, {
       ...valid,
       maybeNotSetYet: true as unknown as string,

--- a/packages/convex-helpers/server/zod.test.ts
+++ b/packages/convex-helpers/server/zod.test.ts
@@ -545,7 +545,7 @@ describe("zod functions", () => {
 
   test("bad redefinition", async () => {
     const t = convexTest(schema, modules);
-    expect(() =>
+    await expect(() =>
       t.query(testApi.badRedefine, {
         a: "foo" as never,
         b: 0,


### PR DESCRIPTION
<!-- Describe your PR here. -->

Clean up warnings of the form

```
Promise returned by `expect(actual).rejects.toThrow(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
```

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
