### PR TITLE
fix filter types to support order

### DIFF
--- a/packages/convex-helpers/server/filter.test.ts
+++ b/packages/convex-helpers/server/filter.test.ts
@@ -55,4 +55,25 @@ test("filter", async () => {
     { name: "8" },
     { name: "9" },
   ]);
+
+  // Check that ordering works, before or after the filter.
+  const withOrder = await t.run((ctx) =>
+    filter(ctx.db.query("tableA").order("desc"), (c) => c.count > 5).collect(),
+  );
+  expect(withOrder).toMatchObject([
+    { count: 9 },
+    { count: 8 },
+    { count: 7 },
+    { count: 6 },
+  ]);
+
+  const withOrderAfter = await t.run((ctx) =>
+    filter(ctx.db.query("tableA"), (c) => c.count > 5).order("desc").collect(),
+  );
+  expect(withOrderAfter).toMatchObject([
+    { count: 9 },
+    { count: 8 },
+    { count: 7 },
+    { count: 6 },
+  ]);
 });

--- a/packages/convex-helpers/server/filter.ts
+++ b/packages/convex-helpers/server/filter.ts
@@ -139,7 +139,7 @@ export type Predicate<T extends GenericTableInfo> = (
   doc: DocumentByInfo<T>,
 ) => Promise<boolean> | boolean;
 
-type QueryTableInfo<Q> = Q extends Query<infer T> ? T : never;
+type QueryTableInfo<Q> = Q extends OrderedQuery<infer T> ? T : never;
 
 /**
  * Applies a filter to a database query, just like `.filter((q) => ...)` but
@@ -183,9 +183,12 @@ type QueryTableInfo<Q> = Q extends Query<infer T> ? T : never;
  *  from the query pipeline.
  * @returns A new query with the filter applied.
  */
-export function filter<Q extends Query<GenericTableInfo>>(
+export function filter<Q extends OrderedQuery<GenericTableInfo>>(
   query: Q,
   predicate: Predicate<QueryTableInfo<Q>>,
 ): Q {
-  return new QueryWithFilter(query, predicate) as any as Q;
+  return new QueryWithFilter<QueryTableInfo<Q>>(
+    query as unknown as OrderedQuery<QueryTableInfo<Q>>,
+    predicate,
+  ) as any as Q;
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->

the docstring of `filter` says that you can apply `filter` to queries that already have an `order`. Let's make it true.

I don't know why I need the cast `query as unknown as OrderedQuery<QueryTableInfo<Q>>`, but it looks safe and nothing is changing at runtime, only types are changing in this PR.

Added a test that previously failed.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
