### PR TITLE
Refactor `streamQuery` out of `getPage`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,11 +2551,10 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -10346,8 +10345,8 @@
         "convex-helpers": "bin.cjs"
       },
       "devDependencies": {
-        "chalk": "5.3.0",
-        "commander": "12.1.0"
+        "chalk": "5.4.1",
+        "commander": "13.0.0"
       },
       "peerDependencies": {
         "convex": "^1.13.0",
@@ -10368,9 +10367,9 @@
       }
     },
     "packages/convex-helpers/dist/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
       "dev": true,
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10339,7 +10339,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.67",
+      "version": "0.1.68-alpha.0",
       "license": "Apache-2.0",
       "bin": {
         "convex-helpers": "bin.cjs"

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.67",
+  "version": "0.1.68-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/server/pagination.ts
+++ b/packages/convex-helpers/server/pagination.ts
@@ -98,6 +98,39 @@ export async function getPage<
   ctx: { db: GenericDatabaseReader<DataModel> },
   request: PageRequest<DataModel, T>,
 ): Promise<PageResponse<DataModel, T>> {
+  const absoluteMaxRows = request.absoluteMaxRows ?? Infinity;
+  const targetMaxRows = request.targetMaxRows ?? DEFAULT_TARGET_MAX_ROWS;
+  const absoluteLimit = request.endIndexKey
+    ? absoluteMaxRows
+    : Math.min(absoluteMaxRows, targetMaxRows);
+  const page: DocumentByName<DataModel, T>[] = [];
+  const indexKeys: IndexKey[] = [];
+  const stream = streamQuery(ctx, request);
+  for await (const [doc, indexKey] of stream) {
+    if (page.length >= absoluteLimit) {
+      return {
+        page,
+        hasMore: true,
+        indexKeys,
+      };
+    }
+    page.push(doc);
+    indexKeys.push(indexKey);
+  }
+  return {
+    page,
+    hasMore: false,
+    indexKeys,
+  };
+}
+
+export async function* streamQuery<
+  DataModel extends GenericDataModel,
+  T extends TableNamesInDataModel<DataModel>,
+>(
+  ctx: { db: GenericDatabaseReader<DataModel> },
+  request: Omit<PageRequest<DataModel, T>, "targetMaxRows" | "absoluteMaxRows">,
+): AsyncGenerator<[DocumentByName<DataModel, T>, IndexKey]> {
   const index = request.index ?? "by_creation_time";
   const indexFields = getIndexFields(request);
   const startIndexKey = request.startIndexKey ?? [];
@@ -122,35 +155,15 @@ export async function getPage<
     startBoundType,
     endBoundType,
   );
-  const absoluteMaxRows = request.absoluteMaxRows ?? Infinity;
-  const targetMaxRows = request.targetMaxRows ?? DEFAULT_TARGET_MAX_ROWS;
-  const absoluteLimit = request.endIndexKey
-    ? absoluteMaxRows
-    : Math.min(absoluteMaxRows, targetMaxRows);
-  const page: DocumentByName<DataModel, T>[] = [];
-  const indexKeys: IndexKey[] = [];
   for (const range of split) {
     const query = ctx.db
       .query(request.table)
       .withIndex(index, rangeToQuery(range))
       .order(order);
     for await (const doc of query) {
-      if (page.length >= absoluteLimit) {
-        return {
-          page,
-          hasMore: true,
-          indexKeys,
-        };
-      }
-      page.push(doc);
-      indexKeys.push(getIndexKey(doc, indexFields));
+      yield [doc, getIndexKey(doc, indexFields)];
     }
   }
-  return {
-    page,
-    hasMore: false,
-    indexKeys,
-  };
 }
 
 //


### PR DESCRIPTION
<!-- Describe your PR here. -->

as implemented here: https://github.com/get-convex/convex-backend/blob/54d629f272c60a88c0784aefabfce11108687468/npm-packages/local-store/shared/pagination.ts#L127

this is a straightforward refactor that gives applications access to the lower-level stream, before page boundaries have been selected.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
