### PR TITLE
fix paginator endCursor when isDone

### DIFF
--- a/packages/convex-helpers/server/pagination.ts
+++ b/packages/convex-helpers/server/pagination.ts
@@ -532,10 +532,12 @@ export class OrderedPaginatorQuery<
     let endIndexKey = this.endIndexKey;
     let endInclusive = this.endInclusive;
     let absoluteMaxRows: number | undefined = opts.numItems;
-    if (opts.endCursor && opts.endCursor !== END_CURSOR) {
-      endIndexKey = jsonToConvex(JSON.parse(opts.endCursor)) as IndexKey;
-      endInclusive = true;
+    if (opts.endCursor) {
       absoluteMaxRows = undefined;
+      if (opts.endCursor !== END_CURSOR) {
+        endIndexKey = jsonToConvex(JSON.parse(opts.endCursor)) as IndexKey;
+        endInclusive = true;
+      }
     }
     const {
       page, hasMore, indexKeys,


### PR DESCRIPTION
<!-- Describe your PR here. -->

there's a bug where `endCursor` is not used for the last page of pagination. What should happen is the last page grows to include everything up to endCursor, like every other page. But what was happening instead is it was being cut off at num-items.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
