### PR TITLE
api-function-spec error handling

### DIFF
--- a/packages/convex-helpers/cli/utils.ts
+++ b/packages/convex-helpers/cli/utils.ts
@@ -53,13 +53,16 @@ export function getFunctionSpec(prod?: boolean, filePath?: string) {
 
       content = fs.readFileSync(tempFile, "utf-8");
     } catch (e) {
+      if (e instanceof Error) {
+        console.error(e.message);
+      }
       console.error(
         chalk.red(
           "\nError retrieving function spec from your Convex deployment. " +
             "Confirm that you \nare running this command from within a Convex project.\n",
         ),
       );
-      process.exit(1);
+      throw e;
     } finally {
       try {
         fs.unlinkSync(tempFile);


### PR DESCRIPTION
<!-- Describe your PR here. -->

in the case of an error, we throw an Error with the result.stderr, but when we catch this error there are two problems:

1. we print a generic error message, discarding the stderr
2. we process.exit which means the finally block never gets called to clean up the temp file

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
