### PR TITLE
add missing case for paginated queries

### DIFF
--- a/src/hooks/useStableQuery.ts
+++ b/src/hooks/useStableQuery.ts
@@ -46,7 +46,7 @@ export const useStablePaginatedQuery = ((name, ...args) => {
 
   // If data is still loading, wait and do nothing
   // If data has finished loading, store the result
-  if (result.status !== "LoadingMore") {
+  if (result.status !== "LoadingMore" && result.status !== "LoadingFirstPage") {
     stored.current = result;
   }
 


### PR DESCRIPTION
It seems useStablePaginatedQuery is missing a loading case to not rerender the UI.
This PR add the missing case and ensures the UI is not rerendering while loading the first page. 

It's particularly visible when a paginated query is used with a `withSearchIndex` and a user is typing a text that does a paginated query. Without this check, the UI keeps rerendering every time the user types on a character on the keyboard.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
