### PR TITLE
improve .unique() error message

### DIFF
--- a/packages/convex-helpers/server/filter.ts
+++ b/packages/convex-helpers/server/filter.ts
@@ -27,7 +27,7 @@ import {
 
 async function asyncFilter<T>(
   arr: T[],
-  predicate: (d: T) => Promise<boolean> | boolean,
+  predicate: (d: T) => Promise<boolean> | boolean
 ): Promise<T[]> {
   const results = await Promise.all(arr.map(predicate));
   return arr.filter((_v, index) => results[index]);
@@ -53,7 +53,7 @@ class QueryWithFilter<T extends GenericTableInfo>
     return new QueryWithFilter(this.q.order(order), this.p);
   }
   async paginate(
-    paginationOpts: PaginationOptions,
+    paginationOpts: PaginationOptions
   ): Promise<PaginationResult<DocumentByInfo<T>>> {
     const result = await this.q.paginate(paginationOpts);
     return { ...result, page: await asyncFilter(result.page, this.p) };
@@ -85,7 +85,8 @@ class QueryWithFilter<T extends GenericTableInfo>
         uniqueResult = result;
       } else {
         throw new Error(
-          `unique() query returned more than one result. First pair of results: ${uniqueResult._id} and ${result._id}`
+          `unique() query returned more than one result: 
+    [${uniqueResult._id}, ${result[1]._id}, ...]`
         );
       }
     }
@@ -118,27 +119,27 @@ class QueryWithFilter<T extends GenericTableInfo>
     indexName: IndexName,
     indexRange?:
       | ((
-          q: IndexRangeBuilder<DocumentByInfo<T>, NamedIndex<T, IndexName>, 0>,
+          q: IndexRangeBuilder<DocumentByInfo<T>, NamedIndex<T, IndexName>, 0>
         ) => IndexRange)
-      | undefined,
+      | undefined
   ): Query<T> {
     return new QueryWithFilter(this.q.withIndex(indexName, indexRange), this.p);
   }
   withSearchIndex<IndexName extends keyof SearchIndexes<T>>(
     indexName: IndexName,
     searchFilter: (
-      q: SearchFilterBuilder<DocumentByInfo<T>, NamedSearchIndex<T, IndexName>>,
-    ) => SearchFilter,
+      q: SearchFilterBuilder<DocumentByInfo<T>, NamedSearchIndex<T, IndexName>>
+    ) => SearchFilter
   ): OrderedQuery<T> {
     return new QueryWithFilter(
       this.q.withSearchIndex(indexName, searchFilter),
-      this.p,
+      this.p
     );
   }
 }
 
 export type Predicate<T extends GenericTableInfo> = (
-  doc: DocumentByInfo<T>,
+  doc: DocumentByInfo<T>
 ) => Promise<boolean> | boolean;
 
 type QueryTableInfo<Q> = Q extends OrderedQuery<infer T> ? T : never;
@@ -187,10 +188,10 @@ type QueryTableInfo<Q> = Q extends OrderedQuery<infer T> ? T : never;
  */
 export function filter<Q extends OrderedQuery<GenericTableInfo>>(
   query: Q,
-  predicate: Predicate<QueryTableInfo<Q>>,
+  predicate: Predicate<QueryTableInfo<Q>>
 ): Q {
   return new QueryWithFilter<QueryTableInfo<Q>>(
     query as unknown as OrderedQuery<QueryTableInfo<Q>>,
-    predicate,
+    predicate
   ) as any as Q;
 }

--- a/packages/convex-helpers/server/filter.ts
+++ b/packages/convex-helpers/server/filter.ts
@@ -85,8 +85,8 @@ class QueryWithFilter<T extends GenericTableInfo>
         uniqueResult = result;
       } else {
         throw new Error(
-          `unique() query returned more than one result: 
-  [${uniqueResult._id}, ${result._id}, ...]`
+          `unique() query returned more than one result:
+  [${uniqueResult._id}, ${result._id}, ...]`,
         );
       }
     }

--- a/packages/convex-helpers/server/filter.ts
+++ b/packages/convex-helpers/server/filter.ts
@@ -84,7 +84,9 @@ class QueryWithFilter<T extends GenericTableInfo>
       if (uniqueResult === null) {
         uniqueResult = result;
       } else {
-        throw new Error("not unique");
+        throw new Error(
+          `unique() query returned more than one result. First pair of results: ${uniqueResult._id} and ${result._id}`
+        );
       }
     }
     return uniqueResult;

--- a/packages/convex-helpers/server/filter.ts
+++ b/packages/convex-helpers/server/filter.ts
@@ -27,7 +27,7 @@ import {
 
 async function asyncFilter<T>(
   arr: T[],
-  predicate: (d: T) => Promise<boolean> | boolean
+  predicate: (d: T) => Promise<boolean> | boolean,
 ): Promise<T[]> {
   const results = await Promise.all(arr.map(predicate));
   return arr.filter((_v, index) => results[index]);
@@ -53,7 +53,7 @@ class QueryWithFilter<T extends GenericTableInfo>
     return new QueryWithFilter(this.q.order(order), this.p);
   }
   async paginate(
-    paginationOpts: PaginationOptions
+    paginationOpts: PaginationOptions,
   ): Promise<PaginationResult<DocumentByInfo<T>>> {
     const result = await this.q.paginate(paginationOpts);
     return { ...result, page: await asyncFilter(result.page, this.p) };
@@ -86,7 +86,7 @@ class QueryWithFilter<T extends GenericTableInfo>
       } else {
         throw new Error(
           `unique() query returned more than one result: 
-    [${uniqueResult._id}, ${result[1]._id}, ...]`
+  [${uniqueResult._id}, ${result._id}, ...]`
         );
       }
     }
@@ -119,27 +119,27 @@ class QueryWithFilter<T extends GenericTableInfo>
     indexName: IndexName,
     indexRange?:
       | ((
-          q: IndexRangeBuilder<DocumentByInfo<T>, NamedIndex<T, IndexName>, 0>
+          q: IndexRangeBuilder<DocumentByInfo<T>, NamedIndex<T, IndexName>, 0>,
         ) => IndexRange)
-      | undefined
+      | undefined,
   ): Query<T> {
     return new QueryWithFilter(this.q.withIndex(indexName, indexRange), this.p);
   }
   withSearchIndex<IndexName extends keyof SearchIndexes<T>>(
     indexName: IndexName,
     searchFilter: (
-      q: SearchFilterBuilder<DocumentByInfo<T>, NamedSearchIndex<T, IndexName>>
-    ) => SearchFilter
+      q: SearchFilterBuilder<DocumentByInfo<T>, NamedSearchIndex<T, IndexName>>,
+    ) => SearchFilter,
   ): OrderedQuery<T> {
     return new QueryWithFilter(
       this.q.withSearchIndex(indexName, searchFilter),
-      this.p
+      this.p,
     );
   }
 }
 
 export type Predicate<T extends GenericTableInfo> = (
-  doc: DocumentByInfo<T>
+  doc: DocumentByInfo<T>,
 ) => Promise<boolean> | boolean;
 
 type QueryTableInfo<Q> = Q extends OrderedQuery<infer T> ? T : never;
@@ -188,10 +188,10 @@ type QueryTableInfo<Q> = Q extends OrderedQuery<infer T> ? T : never;
  */
 export function filter<Q extends OrderedQuery<GenericTableInfo>>(
   query: Q,
-  predicate: Predicate<QueryTableInfo<Q>>
+  predicate: Predicate<QueryTableInfo<Q>>,
 ): Q {
   return new QueryWithFilter<QueryTableInfo<Q>>(
     query as unknown as OrderedQuery<QueryTableInfo<Q>>,
-    predicate
+    predicate,
   ) as any as Q;
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->

_Similar to [this PR I opened](https://github.com/get-convex/convex-backend/pull/59) in the convex-backend repo_

Makes the error message thrown by .unique() more useful. Now, the _id's of the first two documents returned by the unique() query are printed in the error message. This is very helpful to the user in identifying and resolving incorrect data.

The wording in the error message has been changed such that it is identical to the error thrown by `.unique()` from `convex-backend` (slightly confusing that the same error has different error messages based on where it's thrown from).

Feel free to change my wording in the error message - but in my opinion it should be clear that the document id's printed are not all the documents returned by the unique() query but just the first two.

**Note:** I did not build and test this change locally, and intellisense did not help me in verifying that `_id` does indeed exist on those objects, so please verify before merging!


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
