### PR TITLE
Allow ConvexHttpClient in withArgs

### DIFF
--- a/packages/convex-helpers/browser.ts
+++ b/packages/convex-helpers/browser.ts
@@ -1,5 +1,5 @@
 import type { BetterOmit, EmptyObject } from "./index.js";
-import type { ConvexClient } from "convex/browser";
+import type { ConvexClient, ConvexHttpClient } from "convex/browser";
 import type { FunctionArgs, FunctionReturnType } from "convex/server";
 import type { FunctionReference } from "convex/server";
 import type { Value } from "convex/values";
@@ -30,7 +30,7 @@ export type ArgsArray<
  * @returns { query, mutation, action } functions with the injected arguments
  */
 export function withArgs<A extends Record<string, Value>>(
-  client: ConvexClient,
+  client: ConvexClient | ConvexHttpClient,
   injectedArgs: A,
 ) {
   return {


### PR DESCRIPTION
As a future direction how about withArgs can return more full wrappers of various clients? If that works as a plan then it's fine to add more clients here and a type parameter for the client type in the future, but for now it's just the same interface!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.