### PR TITLE
Add standard schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ find the npm package in [./packages/convex-helpers](./packages/convex-helpers).
 | [OpenAPI Spec Generator](./packages/convex-helpers/README.md#open-api-spec-generation)
 | [Triggers](./packages/convex-helpers/README.md#triggers)
 | [CORS for HttpRouter](./packages/convex-helpers/README.md#cors-support-for-httprouter)
+| [Standard Schema support](./packages/convex-helpers/README.md#standard-schema)
 
 | In this directory for copy-pasting:
 | -----------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -8209,7 +8209,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.88-alpha.0",
+      "version": "0.1.88",
       "license": "Apache-2.0",
       "bin": {
         "convex-helpers": "bin.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8209,7 +8209,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.88",
+      "version": "0.1.89-alpha.0",
       "license": "Apache-2.0",
       "bin": {
         "convex-helpers": "bin.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8209,7 +8209,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.87",
+      "version": "0.1.88-alpha.0",
       "license": "Apache-2.0",
       "bin": {
         "convex-helpers": "bin.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@arethetypeswrong/cli": "0.18.1",
         "@edge-runtime/vm": "5.0.0",
         "@redocly/cli": "1.34.3",
+        "@standard-schema/spec": "^1.0.0",
         "@testing-library/react": "16.3.0",
         "@types/babel__core": "7.20.5",
         "@types/jest": "29.5.14",
@@ -2362,6 +2363,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "devOptional": true
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
@@ -8212,6 +8219,7 @@
         "commander": "14.0.0"
       },
       "peerDependencies": {
+        "@standard-schema/spec": "^1.0.0",
         "convex": "^1.13.0",
         "hono": "^4.0.5",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
@@ -8219,6 +8227,9 @@
         "zod": "^3.22.4"
       },
       "peerDependenciesMeta": {
+        "@standard-schema/spec": {
+          "optional": true
+        },
         "hono": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@arethetypeswrong/cli": "0.18.1",
     "@edge-runtime/vm": "5.0.0",
     "@redocly/cli": "1.34.3",
+    "@standard-schema/spec": "^1.0.0",
     "@testing-library/react": "16.3.0",
     "@types/babel__core": "7.20.5",
     "@types/jest": "29.5.14",

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -33,6 +33,7 @@ Table of contents:
     - [What can you do with triggers?](#what-can-you-do-with-triggers)
     - [Trigger semantics](#trigger-semantics)
   - [CORS support for HttpRouter](#cors-support-for-httprouter)
+  - [Standard Schema support](#standard-schema)
 
 ## Custom Functions
 
@@ -1203,4 +1204,22 @@ http.route({
 });
 // Export http (or cors.http)
 export default http;
+```
+
+## Standard Schema
+
+Convex helpers provides a function to convert a validator to a Standard Schema.
+
+```typescript
+import { toStandardSchema } from "convex-helpers/standardSchema";
+
+const standardValidator = toStandardSchema(v.object({
+  name: v.string(),
+  age: v.number(),
+}));
+
+standardValidator["~standard"].validate({
+  name: "John",
+  age: 30,
+});
 ```

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -1215,10 +1215,12 @@ To convert a Convex validator to a Standard Schema, use `toStandardSchema`:
 ```typescript
 import { toStandardSchema } from "convex-helpers/standardSchema";
 
-const standardValidator = toStandardSchema(v.object({
-  name: v.string(),
-  age: v.number(),
-}));
+const standardValidator = toStandardSchema(
+  v.object({
+    name: v.string(),
+    age: v.number(),
+  }),
+);
 
 standardValidator["~standard"].validate({
   name: "John",

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -1208,7 +1208,9 @@ export default http;
 
 ## Standard Schema
 
-Convex helpers provides a function to convert a validator to a Standard Schema.
+[Standard Schema](https://github.com/standard-schema/standard-schema)
+is a specification for validating data.
+To convert a Convex validator to a Standard Schema, use `toStandardSchema`:
 
 ```typescript
 import { toStandardSchema } from "convex-helpers/standardSchema";

--- a/packages/convex-helpers/generate-exports.mjs
+++ b/packages/convex-helpers/generate-exports.mjs
@@ -21,6 +21,7 @@ function entryPointFiles() {
     "./testing.ts",
     "./validators.ts",
     "./server.ts",
+    "./standardSchema.ts",
     "./react.ts",
     ...EntryPointDirectories.map(directoryContents).flat(),
   ];

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.88-alpha.0",
+  "version": "0.1.88",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -27,6 +27,10 @@
       "types": "./server.d.ts",
       "default": "./server.js"
     },
+    "./standardSchema": {
+      "types": "./standardSchema.d.ts",
+      "default": "./standardSchema.js"
+    },
     "./react": {
       "types": "./react.d.ts",
       "default": "./react.js"
@@ -153,6 +157,7 @@
     "commander": "14.0.0"
   },
   "peerDependencies": {
+    "@standard-schema/spec": "^1.0.0",
     "convex": "^1.13.0",
     "hono": "^4.0.5",
     "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
@@ -160,6 +165,9 @@
     "zod": "^3.22.4"
   },
   "peerDependenciesMeta": {
+    "@standard-schema/spec": {
+      "optional": true
+    },
     "hono": {
       "optional": true
     },

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.87",
+  "version": "0.1.88-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.88",
+  "version": "0.1.89-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/standardSchema.test.ts
+++ b/packages/convex-helpers/standardSchema.test.ts
@@ -17,7 +17,7 @@ describe("toStandardSchema", () => {
     const value = ours["~standard"].validate("hello");
     const zods = z.string();
     const zodValue = zods["~standard"].validate("hello");
-    expectTypeOf(value["~standard"]).toEqualTypeOf(zodValue["~standard"]);
+    expectTypeOf(ours["~standard"]).toEqualTypeOf(zods["~standard"]);
     expectTypeOf(value).toEqualTypeOf(zodValue);
   });
 

--- a/packages/convex-helpers/standardSchema.test.ts
+++ b/packages/convex-helpers/standardSchema.test.ts
@@ -1,0 +1,83 @@
+import { toStandardSchema } from "./standardSchema.js";
+import { v } from "convex/values";
+
+describe("toStandardSchema", () => {
+  test("conforms to StandardSchemaV1 for string", () => {
+    const schema = toStandardSchema(v.string());
+    expect(schema).toHaveProperty("~standard");
+    expect(schema["~standard"]).toHaveProperty("version", 1);
+    expect(schema["~standard"]).toHaveProperty("vendor", "convex-helpers");
+    expect(typeof schema["~standard"].validate).toBe("function");
+  });
+
+  test("validates string type", () => {
+    const schema = toStandardSchema(v.string());
+    expect(schema["~standard"].validate("hello")).toEqual({ value: "hello" });
+    const fail = schema["~standard"].validate(123);
+    expect("issues" in fail && fail.issues).toBeTruthy();
+    if ("issues" in fail && fail.issues) {
+      expect(fail.issues[0]?.message).toMatch(/string/);
+    }
+  });
+
+  test("validates number type", () => {
+    const schema = toStandardSchema(v.number());
+    expect(schema["~standard"].validate(42)).toEqual({ value: 42 });
+    const fail = schema["~standard"].validate("not a number");
+    expect("issues" in fail && fail.issues).toBeTruthy();
+    if ("issues" in fail && fail.issues) {
+      expect(fail.issues[0]?.message).toMatch(/number/);
+    }
+  });
+
+  test("validates boolean type", () => {
+    const schema = toStandardSchema(v.boolean());
+    expect(schema["~standard"].validate(true)).toEqual({ value: true });
+    expect(schema["~standard"].validate(false)).toEqual({ value: false });
+    const fail = schema["~standard"].validate("not a boolean");
+    expect("issues" in fail && fail.issues).toBeTruthy();
+    if ("issues" in fail && fail.issues) {
+      expect(fail.issues[0]?.message).toMatch(/boolean/);
+    }
+  });
+
+  test("validates object type", () => {
+    const schema = toStandardSchema(v.object({ foo: v.string() }));
+    expect(schema["~standard"].validate({ foo: "bar" })).toEqual({
+      value: { foo: "bar" },
+    });
+    const fail = schema["~standard"].validate({ foo: 123 });
+    expect("issues" in fail && fail.issues).toBeTruthy();
+    if ("issues" in fail && fail.issues) {
+      expect(fail.issues[0]?.message).toMatch(/string/);
+      expect(fail.issues[0]?.path).toEqual(["foo"]);
+    }
+  });
+
+  test("validates nested object type", () => {
+    const schema = toStandardSchema(
+      v.object({ foo: v.object({ bar: v.string() }) }),
+    );
+    expect(schema["~standard"].validate({ foo: { bar: "baz" } })).toEqual({
+      value: { foo: { bar: "baz" } },
+    });
+    const fail = schema["~standard"].validate({ foo: { bar: 123 } });
+    expect("issues" in fail && fail.issues).toBeTruthy();
+    if ("issues" in fail && fail.issues) {
+      expect(fail.issues[0]?.message).toMatch(/string/);
+      expect(fail.issues[0]?.path).toEqual(["foo", "bar"]);
+    }
+  });
+
+  test("validates array type", () => {
+    const schema = toStandardSchema(v.array(v.number()));
+    expect(schema["~standard"].validate([1, 2, 3])).toEqual({
+      value: [1, 2, 3],
+    });
+    const fail = schema["~standard"].validate([1, "two", 3]);
+    expect("issues" in fail && fail.issues).toBeTruthy();
+    if ("issues" in fail && fail.issues) {
+      expect(fail.issues[0]?.message).toMatch(/number/);
+    }
+  });
+});

--- a/packages/convex-helpers/standardSchema.test.ts
+++ b/packages/convex-helpers/standardSchema.test.ts
@@ -1,5 +1,7 @@
+import { z } from "zod";
 import { toStandardSchema } from "./standardSchema.js";
 import { v } from "convex/values";
+import { expectTypeOf } from "vitest";
 
 describe("toStandardSchema", () => {
   test("conforms to StandardSchemaV1 for string", () => {
@@ -8,6 +10,15 @@ describe("toStandardSchema", () => {
     expect(schema["~standard"]).toHaveProperty("version", 1);
     expect(schema["~standard"]).toHaveProperty("vendor", "convex-helpers");
     expect(typeof schema["~standard"].validate).toBe("function");
+  });
+
+  test("types the same as an equivalent zod validator", () => {
+    const ours = toStandardSchema(v.string());
+    const value = ours["~standard"].validate("hello");
+    const zods = z.string();
+    const zodValue = zods["~standard"].validate("hello");
+    expectTypeOf(value["~standard"]).toEqualTypeOf(zodValue["~standard"]);
+    expectTypeOf(value).toEqualTypeOf(zodValue);
   });
 
   test("validates string type", () => {

--- a/packages/convex-helpers/standardSchema.ts
+++ b/packages/convex-helpers/standardSchema.ts
@@ -1,10 +1,9 @@
 import type { GenericDatabaseReader } from "convex/server";
 
-import type { Validator } from "convex/values";
+import type { Infer, Validator } from "convex/values";
 
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { validate, ValidationError } from "./validators.js";
-import type { Value } from "convex/values";
 import type { GenericDataModel } from "convex/server";
 
 /**
@@ -13,10 +12,7 @@ import type { GenericDataModel } from "convex/server";
  * @param opts - Options for the validation.
  * @returns The Standard Schema validator with the type of the Convex validator.
  */
-export function toStandardSchema<
-  T extends Value,
-  V extends Validator<T, any, any>,
->(
+export function toStandardSchema<V extends Validator<any, any, any>>(
   validator: V,
   opts?: {
     /* If provided, v.id validation will check that the id is for the table. */
@@ -28,7 +24,7 @@ export function toStandardSchema<
     are validating a value at a sub-path within some parent object. */
     _pathPrefix?: string;
   },
-): StandardSchemaV1<T> {
+): StandardSchemaV1<Infer<V>> {
   return {
     "~standard": {
       version: 1,
@@ -36,7 +32,7 @@ export function toStandardSchema<
       validate: (value) => {
         try {
           validate(validator, value, { ...opts, throw: true });
-          return { value } as StandardSchemaV1.SuccessResult<T>;
+          return { value } as StandardSchemaV1.SuccessResult<Infer<V>>;
         } catch (e) {
           if (e instanceof ValidationError) {
             return {

--- a/packages/convex-helpers/standardSchema.ts
+++ b/packages/convex-helpers/standardSchema.ts
@@ -1,0 +1,50 @@
+import type { GenericDatabaseReader } from "convex/server";
+
+import type { Validator } from "convex/values";
+
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { validate, ValidationError } from "./validators.js";
+import type { Value } from "convex/values";
+import type { GenericDataModel } from "convex/server";
+
+export function toStandardSchema<
+  T extends Value,
+  V extends Validator<T, any, any>,
+>(
+  validator: V,
+  opts?: {
+    /* If provided, v.id validation will check that the id is for the table. */
+    db?: GenericDatabaseReader<GenericDataModel>;
+    /* If true, allow fields that are not in an object validator. */
+    allowUnknownFields?: boolean;
+    /* A prefix for the path of the value being validated, for error reporting.
+    This is mostly used for recursive calls, do not set it manually unless you
+    are validating a value at a sub-path within some parent object. */
+    _pathPrefix?: string;
+  },
+): StandardSchemaV1<T> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "convex-helpers",
+      validate: (value) => {
+        try {
+          validate(validator, value, { ...opts, throw: true });
+          return { value } as StandardSchemaV1.SuccessResult<T>;
+        } catch (e) {
+          if (e instanceof ValidationError) {
+            return {
+              issues: [
+                {
+                  message: e.message,
+                  path: e.path ? e.path.split(".") : undefined,
+                },
+              ],
+            } as StandardSchemaV1.FailureResult;
+          }
+          throw e;
+        }
+      },
+    },
+  };
+}

--- a/packages/convex-helpers/standardSchema.ts
+++ b/packages/convex-helpers/standardSchema.ts
@@ -7,6 +7,12 @@ import { validate, ValidationError } from "./validators.js";
 import type { Value } from "convex/values";
 import type { GenericDataModel } from "convex/server";
 
+/**
+ * Convert a Convex validator to a Standard Schema.
+ * @param validator - The Convex validator to convert.
+ * @param opts - Options for the validation.
+ * @returns The Standard Schema validator with the type of the Convex validator.
+ */
 export function toStandardSchema<
   T extends Value,
   V extends Validator<T, any, any>,


### PR DESCRIPTION
not quite #558 but at least you can do something like 

```ts
import { toStandardSchema } from "convex-helpers/standardSchema";

const standardValidator = toStandardSchema(v.object({
  name: v.string(),
  age: v.number(),
}));

standardValidator["~standard"].validate({
  name: "John",
  age: 30,
});
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.