### PR TITLE
Fix misspelling in zod comment

### DIFF
--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -486,7 +486,7 @@ export type CustomBuilder<
               /**
                * @deprecated Use `returns` instead.
                * Older version of `returns` that does not also do convex
-               * validation on the output value of the funciton.
+               * validation on the output value of the function.
                * Note: you can't pass an object directly without wrapping it
                * in `z.object()`.
                */


### PR DESCRIPTION
## Summary
- fix a typo in `packages/convex-helpers/server/zod.ts`

## Testing
- `npm test` *(fails: vitest not found)*