### PR TITLE
Fix temp file warning path

### DIFF
--- a/packages/convex-helpers/cli/utils.ts
+++ b/packages/convex-helpers/cli/utils.ts
@@ -72,7 +72,7 @@ export function getFunctionSpec(prod?: boolean, filePath?: string) {
       } catch (error) {
         console.warn(
           chalk.yellow(
-            `Warning: Failed to delete temporary file ${filePath}:`,
+            `Warning: Failed to delete temporary file ${tempFile}:`,
             error instanceof Error ? error.message : "Unknown error",
           ),
         );


### PR DESCRIPTION
## Summary
- correct path in warning when temp file deletion fails

## Testing
- `npm test` *(fails: vitest not found)*