### PR TITLE
fix: add type annotations to imports in  tsApiSpec

### DIFF
--- a/packages/convex-helpers/cli/functions.test.ts
+++ b/packages/convex-helpers/cli/functions.test.ts
@@ -81,8 +81,8 @@ export const FUNCTIONS_JSON = `{
   }`;
 
 export const JS_API = `
-import { FunctionReference, anyApi } from "convex/server"
-import { GenericId as Id } from "convex/values"
+import { type FunctionReference, anyApi } from "convex/server"
+import { type GenericId as Id } from "convex/values"
 
 export const api: PublicApiType = anyApi as unknown as PublicApiType;
 export const internal: InternalApiType = anyApi as unknown as InternalApiType;

--- a/packages/convex-helpers/cli/tsApiSpec.ts
+++ b/packages/convex-helpers/cli/tsApiSpec.ts
@@ -184,8 +184,8 @@ export function generateApiSpec(
     includeInternal ? internalFunctionTree : {},
   );
   return `
-import { FunctionReference, anyApi } from "convex/server"
-import { GenericId as Id } from "convex/values"
+import { type FunctionReference, anyApi } from "convex/server"
+import { type GenericId as Id } from "convex/values"
 
 export const api: PublicApiType = anyApi as unknown as PublicApiType;
 export const internal: InternalApiType = anyApi as unknown as InternalApiType;


### PR DESCRIPTION
Use type imports when generating tsApiSpec.

This syntax is supported in Typescript versions 3.8.0 and above which was released in February 2020.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
