### PR TITLE
fix stream pagination for descending cursors

### DIFF
--- a/convex/counter.ts
+++ b/convex/counter.ts
@@ -1,3 +1,4 @@
+import { paginationOptsValidator } from "convex/server";
 import { action, query } from "./_generated/server";
 // Using mutation from triggersExample so any changes will run triggers
 import { mutation } from "./triggersExample";
@@ -19,6 +20,13 @@ export const getCounters = query({
   args: {},
   handler: async ({ db }) => {
     return db.query("counter_table").collect();
+  },
+});
+
+export const getCountersPaginated = query({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async ({ db }, { paginationOpts }) => {
+    return db.query("counter_table").order("desc").paginate(paginationOpts);
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8270,7 +8270,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.90",
+      "version": "0.1.91-alpha.0",
       "license": "Apache-2.0",
       "bin": {
         "convex-helpers": "bin.cjs"

--- a/packages/convex-helpers/CHANGELOG.md
+++ b/packages/convex-helpers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.91-alpha.0
+
+- Fix descending pagination of paginator/ streams helpers
+
 ## 0.1.90
 
 - Support unions with `parse` and `validate(... { throws: true })`

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.90",
+  "version": "0.1.91-alpha.0",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/react/cache.ts
+++ b/packages/convex-helpers/react/cache.ts
@@ -1,2 +1,2 @@
 export { ConvexQueryCacheProvider } from "./cache/provider.js";
-export { useQuery, useQueries } from "./cache/hooks.js";
+export { useQuery, useQueries, usePaginatedQuery } from "./cache/hooks.js";

--- a/packages/convex-helpers/react/cache/hooks.ts
+++ b/packages/convex-helpers/react/cache/hooks.ts
@@ -1,14 +1,31 @@
-import type { OptionalRestArgsOrSkip, RequestForQueries } from "convex/react";
-import { ConvexProvider, useQueries as useQueriesCore } from "convex/react";
+import type {
+  OptionalRestArgsOrSkip,
+  PaginatedQueryArgs,
+  PaginatedQueryReference,
+  RequestForQueries,
+  UsePaginatedQueryReturnType,
+} from "convex/react";
+import {
+  ConvexProvider,
+  useConvex,
+  useQueries as useQueriesCore,
+} from "convex/react";
 import type {
   FunctionArgs,
   FunctionReference,
   FunctionReturnType,
+  paginationOptsValidator,
+  PaginationResult,
 } from "convex/server";
 import { getFunctionName } from "convex/server";
-import { useContext, useEffect, useMemo } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { ConvexQueryCacheContext } from "./provider.js";
-import { convexToJson } from "convex/values";
+import {
+  ConvexError,
+  convexToJson,
+  type Infer,
+  type Value,
+} from "convex/values";
 
 const uuid =
   typeof crypto !== "undefined" && crypto.randomUUID
@@ -161,4 +178,364 @@ function createQueryKey<Query extends FunctionReference<"query">>(
   const key = [queryString, convexToJson(args)];
   const queryKey = JSON.stringify(key);
   return queryKey;
+}
+
+// NOTE!: We use the same ID so it's always cached, but it can mean a split is
+// required off the bat if it's an old stale query result.
+function nextPaginationId(): number {
+  return 0;
+}
+
+/**
+ * NOTE: The below is copied verbatim from the convex package, using the cached
+ * useQueries implementation.
+ */
+
+// Incrementing integer for each page queried in the usePaginatedQuery hook.
+type QueryPageKey = number;
+
+type UsePaginatedQueryState = {
+  query: FunctionReference<"query">;
+  args: Record<string, Value>;
+  id: number;
+  nextPageKey: QueryPageKey;
+  pageKeys: QueryPageKey[];
+  queries: Record<
+    QueryPageKey,
+    {
+      query: FunctionReference<"query">;
+      // Use the validator type as a test that it matches the args
+      // we generate.
+      args: { paginationOpts: Infer<typeof paginationOptsValidator> };
+    }
+  >;
+  ongoingSplits: Record<QueryPageKey, [QueryPageKey, QueryPageKey]>;
+  skip: boolean;
+};
+
+const splitQuery =
+  (key: QueryPageKey, splitCursor: string, continueCursor: string) =>
+  (prevState: UsePaginatedQueryState) => {
+    const queries = { ...prevState.queries };
+    const splitKey1 = prevState.nextPageKey;
+    const splitKey2 = prevState.nextPageKey + 1;
+    const nextPageKey = prevState.nextPageKey + 2;
+    queries[splitKey1] = {
+      query: prevState.query,
+      args: {
+        ...prevState.args,
+        paginationOpts: {
+          ...prevState.queries[key]!.args.paginationOpts,
+          endCursor: splitCursor,
+        },
+      },
+    };
+    queries[splitKey2] = {
+      query: prevState.query,
+      args: {
+        ...prevState.args,
+        paginationOpts: {
+          ...prevState.queries[key]!.args.paginationOpts,
+          cursor: splitCursor,
+          endCursor: continueCursor,
+        },
+      },
+    };
+    const ongoingSplits = { ...prevState.ongoingSplits };
+    ongoingSplits[key] = [splitKey1, splitKey2];
+    return {
+      ...prevState,
+      nextPageKey,
+      queries,
+      ongoingSplits,
+    };
+  };
+
+const completeSplitQuery =
+  (key: QueryPageKey) => (prevState: UsePaginatedQueryState) => {
+    const completedSplit = prevState.ongoingSplits[key];
+    if (completedSplit === undefined) {
+      return prevState;
+    }
+    const queries = { ...prevState.queries };
+    delete queries[key];
+    const ongoingSplits = { ...prevState.ongoingSplits };
+    delete ongoingSplits[key];
+    let pageKeys = prevState.pageKeys.slice();
+    const pageIndex = prevState.pageKeys.findIndex((v) => v === key);
+    if (pageIndex >= 0) {
+      pageKeys = [
+        ...prevState.pageKeys.slice(0, pageIndex),
+        ...completedSplit,
+        ...prevState.pageKeys.slice(pageIndex + 1),
+      ];
+    }
+    return {
+      ...prevState,
+      queries,
+      pageKeys,
+      ongoingSplits,
+    };
+  };
+
+/**
+ * Load data reactively from a paginated query to a create a growing list.
+ *
+ * This can be used to power "infinite scroll" UIs.
+ *
+ * This hook must be used with public query references that match
+ * {@link PaginatedQueryReference}.
+ *
+ * `usePaginatedQuery` concatenates all the pages of results into a single list
+ * and manages the continuation cursors when requesting more items.
+ *
+ * Example usage:
+ * ```typescript
+ * const { results, status, isLoading, loadMore } = usePaginatedQuery(
+ *   api.messages.list,
+ *   { channel: "#general" },
+ *   { initialNumItems: 5 }
+ * );
+ * ```
+ *
+ * If the query reference or arguments change, the pagination state will be reset
+ * to the first page. Similarly, if any of the pages result in an InvalidCursor
+ * error or an error associated with too much data, the pagination state will also
+ * reset to the first page.
+ *
+ * To learn more about pagination, see [Paginated Queries](https://docs.convex.dev/database/pagination).
+ *
+ * @param query - A FunctionReference to the public query function to run.
+ * @param args - The arguments object for the query function, excluding
+ * the `paginationOpts` property. That property is injected by this hook.
+ * @param options - An object specifying the `initialNumItems` to be loaded in
+ * the first page.
+ * @returns A {@link UsePaginatedQueryResult} that includes the currently loaded
+ * items, the status of the pagination, and a `loadMore` function.
+ *
+ * @public
+ */
+export function usePaginatedQuery<Query extends PaginatedQueryReference>(
+  query: Query,
+  args: PaginatedQueryArgs<Query> | "skip",
+  options: { initialNumItems: number },
+): UsePaginatedQueryReturnType<Query> {
+  if (
+    typeof options?.initialNumItems !== "number" ||
+    options.initialNumItems < 0
+  ) {
+    throw new Error(
+      `\`options.initialNumItems\` must be a positive number. Received \`${options?.initialNumItems}\`.`,
+    );
+  }
+  const skip = args === "skip";
+  const argsObject = skip ? {} : args;
+  const queryName = getFunctionName(query);
+  const createInitialState = useMemo(() => {
+    return () => {
+      const id = nextPaginationId();
+      return {
+        query,
+        args: argsObject as Record<string, Value>,
+        id,
+        nextPageKey: 1,
+        pageKeys: skip ? [] : [0],
+        queries: skip
+          ? ({} as UsePaginatedQueryState["queries"])
+          : {
+              0: {
+                query,
+                args: {
+                  ...argsObject,
+                  paginationOpts: {
+                    numItems: options.initialNumItems,
+                    cursor: null,
+                    id,
+                  },
+                },
+              },
+            },
+        ongoingSplits: {},
+        skip,
+      };
+    };
+    // ESLint doesn't like that we're stringifying the args. We do this because
+    // we want to avoid rerendering if the args are a different
+    // object that serializes to the same result.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    JSON.stringify(convexToJson(argsObject as Value)),
+    queryName,
+    options.initialNumItems,
+    skip,
+  ]);
+
+  const [state, setState] =
+    useState<UsePaginatedQueryState>(createInitialState);
+
+  // `currState` is the state that we'll render based on.
+  let currState = state;
+  if (
+    getFunctionName(query) !== getFunctionName(state.query) ||
+    JSON.stringify(convexToJson(argsObject as Value)) !==
+      JSON.stringify(convexToJson(state.args)) ||
+    skip !== state.skip
+  ) {
+    currState = createInitialState();
+    setState(currState);
+  }
+  const convexClient = useConvex();
+  const logger = convexClient.logger;
+
+  const resultsObject = useQueries(currState.queries);
+
+  const [results, maybeLastResult]: [
+    Value[],
+    undefined | PaginationResult<Value>,
+  ] = useMemo(() => {
+    let currResult: PaginationResult<Value> | undefined = undefined;
+
+    const allItems: Value[] = [];
+    for (const pageKey of currState.pageKeys) {
+      currResult = resultsObject[pageKey];
+      if (currResult === undefined) {
+        break;
+      }
+
+      if (currResult instanceof Error) {
+        if (
+          currResult.message.includes("InvalidCursor") ||
+          (currResult instanceof ConvexError &&
+            typeof currResult.data === "object" &&
+            currResult.data?.isConvexSystemError === true &&
+            currResult.data?.paginationError === "InvalidCursor")
+        ) {
+          // - InvalidCursor: If the cursor is invalid, probably the paginated
+          // database query was data-dependent and changed underneath us. The
+          // cursor in the params or journal no longer matches the current
+          // database query.
+
+          // In all cases, we want to restart pagination to throw away all our
+          // existing cursors.
+          logger.warn(
+            "usePaginatedQuery hit error, resetting pagination state: " +
+              currResult.message,
+          );
+          setState(createInitialState);
+          return [[], undefined];
+        } else {
+          throw currResult;
+        }
+      }
+      const ongoingSplit = currState.ongoingSplits[pageKey];
+      if (ongoingSplit !== undefined) {
+        if (
+          resultsObject[ongoingSplit[0]] !== undefined &&
+          resultsObject[ongoingSplit[1]] !== undefined
+        ) {
+          // Both pages of the split have results now. Swap them in.
+          setState(completeSplitQuery(pageKey));
+        }
+      } else if (
+        currResult.splitCursor &&
+        (currResult.pageStatus === "SplitRecommended" ||
+          currResult.pageStatus === "SplitRequired" ||
+          currResult.page.length > options.initialNumItems * 2)
+      ) {
+        // If a single page has more than double the expected number of items,
+        // or if the server requests a split, split the page into two.
+        setState(
+          splitQuery(
+            pageKey,
+            currResult.splitCursor,
+            currResult.continueCursor,
+          ),
+        );
+      }
+      if (currResult.pageStatus === "SplitRequired") {
+        // If pageStatus is 'SplitRequired', it means the server was not able to
+        // fetch the full page. So we stop results before the incomplete
+        // page and return 'LoadingMore' while the page is splitting.
+        return [allItems, undefined];
+      }
+      allItems.push(...currResult.page);
+    }
+    return [allItems, currResult];
+  }, [
+    resultsObject,
+    currState.pageKeys,
+    currState.ongoingSplits,
+    options.initialNumItems,
+    createInitialState,
+    logger,
+  ]);
+
+  const statusObject = useMemo(() => {
+    if (maybeLastResult === undefined) {
+      if (currState.nextPageKey === 1) {
+        return {
+          status: "LoadingFirstPage",
+          isLoading: true,
+          loadMore: (_numItems: number) => {
+            // Intentional noop.
+          },
+        } as const;
+      } else {
+        return {
+          status: "LoadingMore",
+          isLoading: true,
+          loadMore: (_numItems: number) => {
+            // Intentional noop.
+          },
+        } as const;
+      }
+    }
+    if (maybeLastResult.isDone) {
+      return {
+        status: "Exhausted",
+        isLoading: false,
+        loadMore: (_numItems: number) => {
+          // Intentional noop.
+        },
+      } as const;
+    }
+    const continueCursor = maybeLastResult.continueCursor;
+    let alreadyLoadingMore = false;
+    return {
+      status: "CanLoadMore",
+      isLoading: false,
+      loadMore: (numItems: number) => {
+        if (!alreadyLoadingMore) {
+          alreadyLoadingMore = true;
+          setState((prevState) => {
+            const pageKeys = [...prevState.pageKeys, prevState.nextPageKey];
+            const queries = { ...prevState.queries };
+            queries[prevState.nextPageKey] = {
+              query: prevState.query,
+              args: {
+                ...prevState.args,
+                paginationOpts: {
+                  numItems,
+                  cursor: continueCursor,
+                  id: prevState.id,
+                },
+              },
+            };
+            return {
+              ...prevState,
+              nextPageKey: prevState.nextPageKey + 1,
+              pageKeys,
+              queries,
+            };
+          });
+        }
+      },
+    } as const;
+  }, [maybeLastResult, currState.nextPageKey]);
+
+  return {
+    results,
+    ...statusObject,
+  };
 }

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -223,20 +223,19 @@ describe("stream", () => {
       await ctx.db.insert("foo", { a: 1, b: 2, c: 2 });
       await ctx.db.insert("foo", { a: 1, b: 3, c: 2 });
       await ctx.db.insert("foo", { a: 1, b: 2, c: 3 });
-      const query = stream(ctx.db, schema)
-        .query("foo")
-        .withIndex("abc", (q) => q.eq("a", 1).gt("b", 2));
+      const query = stream(ctx.db, schema).query("foo").withIndex("abc");
       const result = await query.paginate({ numItems: 1, cursor: null });
       expect(result.page.map(stripSystemFields)).toEqual([
-        { a: 1, b: 3, c: 1 },
+        { a: 1, b: 2, c: 1 },
       ]);
       expect(result.isDone).toBe(false);
       const result2 = await query.paginate({
-        numItems: 1,
+        numItems: 2,
         cursor: result.continueCursor,
       });
       expect(result2.page.map(stripSystemFields)).toEqual([
-        { a: 1, b: 2, c: 1 },
+        { a: 1, b: 2, c: 2 },
+        { a: 1, b: 2, c: 3 },
       ]);
       expect(result2.isDone).toBe(false);
       const result3 = await query.paginate({
@@ -244,7 +243,7 @@ describe("stream", () => {
         cursor: result2.continueCursor,
       });
       expect(result3.page.map(stripSystemFields)).toEqual([
-        { a: 1, b: 2, c: 2 },
+        { a: 1, b: 3, c: 1 },
       ]);
       expect(result3.isDone).toBe(false);
     });

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -132,6 +132,7 @@ describe("stream", () => {
       const result = await query.collect();
       expect(result.map(stripSystemFields)).toEqual([
         { a: 1, b: 4, c: 3 },
+        { a: 1, b: 3, c: 4 },
         { a: 1, b: 3, c: 3 },
       ]);
     });
@@ -145,14 +146,13 @@ describe("stream", () => {
       await ctx.db.insert("foo", { a: 1, b: 3, c: 4 });
       await ctx.db.insert("foo", { a: 1, b: 4, c: 3 });
       await ctx.db.insert("foo", { a: 1, b: 4, c: 4 });
-      await ctx.db.insert("foo", { a: 1, b: 4, c: 5 });
       const query = stream(ctx.db, schema)
         .query("foo")
         .withIndex("abc", (q) => q.eq("a", 1).gt("b", 2));
       const resultPage1 = await query.paginate({ numItems: 2, cursor: null });
       expect(resultPage1.page.map(stripSystemFields)).toEqual([
         { a: 1, b: 3, c: 3 },
-        { a: 1, b: 4, c: 3 },
+        { a: 1, b: 3, c: 4 },
       ]);
       expect(resultPage1.isDone).toBe(false);
       const resultPage2 = await query.paginate({
@@ -160,8 +160,8 @@ describe("stream", () => {
         cursor: resultPage1.continueCursor,
       });
       expect(resultPage2.page.map(stripSystemFields)).toEqual([
+        { a: 1, b: 4, c: 3 },
         { a: 1, b: 4, c: 4 },
-        { a: 1, b: 4, c: 5 },
       ]);
       expect(resultPage2.isDone).toBe(false);
       const resultPage3 = await query.paginate({

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -140,6 +140,7 @@ describe("stream", () => {
     await t.run(async (ctx) => {
       await ctx.db.insert("foo", { a: 1, b: 2, c: 3 });
       await ctx.db.insert("foo", { a: 1, b: 3, c: 3 });
+      await ctx.db.insert("foo", { a: 1, b: 3, c: 4 });
       await ctx.db.insert("foo", { a: 1, b: 4, c: 3 });
       await ctx.db.insert("foo", { a: 1, b: 4, c: 4 });
       await ctx.db.insert("foo", { a: 1, b: 4, c: 5 });

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -121,7 +121,9 @@ describe("stream", () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       await ctx.db.insert("foo", { a: 1, b: 2, c: 3 });
+      await ctx.db.insert("foo", { a: 1, b: 2, c: 4 });
       await ctx.db.insert("foo", { a: 1, b: 3, c: 3 });
+      await ctx.db.insert("foo", { a: 1, b: 3, c: 4 });
       await ctx.db.insert("foo", { a: 1, b: 4, c: 3 });
       const query = stream(ctx.db, schema)
         .query("foo")

--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -833,15 +833,12 @@ export function streamIndexRange<
     bounds.lowerBoundInclusive ? "gte" : "gt",
     bounds.upperBoundInclusive ? "lte" : "lt",
   );
-  const subQueries: OrderedStreamQuery<Schema, T, IndexName>[] = [];
-  for (const splitBound of splitBounds) {
-    subQueries.push(
-      stream(db, schema)
-        .query(table)
-        .withIndex(index, rangeToQuery(splitBound))
-        .order(order),
-    );
-  }
+  const subQueries = splitBounds.map((splitBound) =>
+    stream(db, schema)
+      .query(table)
+      .withIndex(index, rangeToQuery(splitBound))
+      .order(order),
+  );
   return new ConcatStreams(...subQueries);
 }
 

--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -52,6 +52,8 @@ type Bound = ["gt" | "lt" | "gte" | "lte" | "eq", string, Value];
  */
 function splitRange(
   indexFields: string[],
+  // For descending queries, the resulting queries are reversed.
+  order: "asc" | "desc",
   startBound: IndexKey,
   endBound: IndexKey,
   startBoundType: "gt" | "lt" | "gte" | "lte",
@@ -116,7 +118,11 @@ function splitRange(
     middleRange.push([startBoundType, indexFields[0]!, startValue]);
     middleRange.push([endBoundType, indexFields[0]!, endValue]);
   }
-  return [...startRanges, middleRange, ...endRanges];
+  const ranges = [...startRanges, middleRange, ...endRanges];
+  if (order === "desc") {
+    ranges.reverse();
+  }
+  return ranges;
 }
 
 function rangeToQuery(range: Bound[]) {
@@ -821,6 +827,7 @@ export function streamIndexRange<
   const indexFields = getIndexFields(table, index, schema);
   const splitBounds = splitRange(
     indexFields,
+    order,
     bounds.lowerBound,
     bounds.upperBound,
     bounds.lowerBoundInclusive ? "gte" : "gt",

--- a/src/components/CacheExample.tsx
+++ b/src/components/CacheExample.tsx
@@ -1,11 +1,15 @@
 import { FC, useRef, useState } from "react";
-import { useQuery } from "convex-helpers/react/cache";
+import {
+  useQuery,
+  usePaginatedQuery,
+  useQueries,
+} from "convex-helpers/react/cache";
 import { api } from "../../convex/_generated/api";
 
 // Composing this with the tanstack-style useQuery:
-// import { makeUseQueryWithStatus } from "convex-helpers/react";
-// import { useQueries } from "convex-helpers/react/cache";
-// const useQuery= makeUseQueryWithStatus(useQueries);
+import { makeUseQueryWithStatus } from "convex-helpers/react";
+import { useMutation } from "convex/react";
+const useQueryWithStatus = makeUseQueryWithStatus(useQueries);
 
 export const CacheExample: FC = () => {
   const [count, setCount] = useState(4);
@@ -36,12 +40,30 @@ export const CacheExample: FC = () => {
         onChange={updateCount}
       />
       <ul>{children}</ul>
-      <div>This is an element that skips:</div>
       <div>
-        <button onClick={() => setSkip((skip) => !skip)}>
-          {skip ? "Unskip" : "Skip"}
-        </button>
-        <Added top={count % 2 ? -1 : count} skip={skip} />
+        Try skipping and see that the non-skipped value is already there:
+      </div>
+      <button onClick={() => setSkip((skip) => !skip)}>
+        {skip ? "Unskip" : "Skip"}
+      </button>
+      <div className="flex flex-row gap-8">
+        <div className="flex-1 flex flex-col gap-2">
+          <Added top={count % 2 ? -1 : count} skip={skip} />
+          <div>Skipping the paginated query:</div>
+          <Paginated skip={skip} />
+        </div>
+        <div className="flex-1 flex flex-col gap-2">
+          <div>
+            Optionally rendering the component should also show up instantly:
+          </div>
+          {skip ? (
+            <div>Skipped</div>
+          ) : (
+            <Added top={count % 2 ? -1 : count} skip={false} />
+          )}
+          <div>Reloading the paginated query:</div>
+          {skip ? <div>Skipped</div> : <Paginated skip={false} />}
+        </div>
       </div>
     </>
   );
@@ -49,12 +71,20 @@ export const CacheExample: FC = () => {
 
 const Added: FC<{ top: number; skip?: boolean }> = ({ top, skip }) => {
   const sum = useQuery(api.addIt.addItUp, skip ? "skip" : { top });
+  const sumWithStatus = useQueryWithStatus(
+    api.addIt.addItUp,
+    skip ? "skip" : { top },
+  );
+  if (
+    sumWithStatus.data !== sum ||
+    sumWithStatus.isPending !== (sum === undefined) ||
+    sumWithStatus.isSuccess !== (sum !== undefined)
+  ) {
+    throw new Error("These should never mismatch");
+  }
+
   if (sum === undefined) {
-    // If you want to try the tanstack-style useQuery:
-    // const { data: sum, isPending, error } = useQuery(api.addIt.addItUp, args);
-    // if (error) throw error;
-    // if (isPending) {
-    if (skip) return <li>Skipping...</li>;
+    if (skip) return <li>Skipped</li>;
     return <li>Loading {top}...</li>;
   } else {
     return (
@@ -64,3 +94,36 @@ const Added: FC<{ top: number; skip?: boolean }> = ({ top, skip }) => {
     );
   }
 };
+
+function Paginated({ skip }: { skip: boolean }) {
+  const counters = usePaginatedQuery(
+    api.counter.getCountersPaginated,
+    skip ? "skip" : {},
+    { initialNumItems: 2 },
+  );
+  const addCounter = useMutation(api.counter.incrementCounter);
+  if (skip) {
+    return <div>Skipped</div>;
+  }
+  return (
+    <div>
+      <ul>
+        {counters.results.map((counter, i) => (
+          <li key={i}>
+            {counter.name}: {counter.counter}
+          </li>
+        ))}
+      </ul>
+      <button
+        onClick={() =>
+          addCounter({ counterName: "test-" + Date.now(), increment: 1 })
+        }
+      >
+        Add Counter
+      </button>
+      {counters.status === "CanLoadMore" && (
+        <button onClick={() => counters.loadMore(2)}>Load More</button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes #630

We were producing ranges to query that were like
a lt 2
a eq 2, b lt 3
a eq 2, b eq 3, c lt 4
...

but for descending iteration, we need these ranges to be reversed, which is important for ConcatStreams

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
