### PR TITLE
Fix types on customFunctions

### DIFF
--- a/packages/convex-helpers/server/customFunctions.test.ts
+++ b/packages/convex-helpers/server/customFunctions.test.ts
@@ -367,7 +367,7 @@ export const outerExtender = customQuery(inner, {
 export const outerExtends = outerExtender({
   args: { a: v.string() },
   handler: async (ctx, args) => {
-    return { outer: ctx.outer, ...args };
+    return { outer: ctx.outer, inner: ctx.inner, ...args };
   },
 });
 
@@ -580,6 +580,7 @@ describe("nested custom functions", () => {
     expect(
       await t.query(testApi.outerExtends, { a: "hi", outer: "extended" }),
     ).toMatchObject({
+      inner: "inner",
       outer: ["extended", "inner"],
       a: "hi",
     });

--- a/packages/convex-helpers/server/customFunctions.test.ts
+++ b/packages/convex-helpers/server/customFunctions.test.ts
@@ -358,6 +358,18 @@ export const outerRemoves = outerRemover({
     return { ctxInner: ctx["inner"], ctxOuter: ctx["outer"], ...args };
   },
 });
+export const outerExtender = customQuery(inner, {
+  args: { outer: v.string() },
+  input: async (ctx, args) => {
+    return { ctx: { outer: [args.outer, ctx.inner] }, args: {} };
+  },
+});
+export const outerExtends = outerExtender({
+  args: { a: v.string() },
+  handler: async (ctx, args) => {
+    return { outer: ctx.outer, ...args };
+  },
+});
 
 /**
  * Test helpers
@@ -388,6 +400,7 @@ const testApi: ApiFromModules<{
     create: typeof create;
     outerAdds: typeof outerAdds;
     outerRemoves: typeof outerRemoves;
+    outerExtends: typeof outerExtends;
   };
 }>["fns"] = anyApi["customFunctions.test"] as any;
 
@@ -558,6 +571,16 @@ describe("nested custom functions", () => {
     expect(
       await t.query(testApi.outerRemoves, { a: "hi", outer: "bye" }),
     ).toMatchObject({
+      a: "hi",
+    });
+  });
+
+  test("extends prev ctx", async () => {
+    const t = convexTest(schema, modules);
+    expect(
+      await t.query(testApi.outerExtends, { a: "hi", outer: "extended" }),
+    ).toMatchObject({
+      outer: ["extended", "inner"],
       a: "hi",
     });
   });


### PR DESCRIPTION
Note: Currently, this PR only adds missing test that fail type checking but correctly passes tests.

---


Custom functions are incorrectly typed because the given query/mutation/action to extend is assumed that has the same type definition as the base convex function builders. This is inconvenient when a custom function want's to extend another, like in the new added tests.