### PR TITLE
Custom function allows extra params

### DIFF
--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -52,7 +52,7 @@ See the associated [Stack Post](https://stack.convex.dev/custom-functions)
 
 For example:
 
-```js
+```ts
 import { customQuery } from "convex-helpers/server/customFunctions.js";
 
 const myQueryBuilder = customQuery(query, {
@@ -70,6 +70,34 @@ export const getSomeData = myQueryBuilder({
   handler: async (ctx, args) => {
     const { db, apiUser, scheduler } = ctx;
     const { someArg } = args;
+    // ...
+  },
+});
+```
+
+### Taking in extra arguments
+
+You can take in extra arguments to a custom function by specifying the type of a third `input` arg.
+
+```ts
+const myQueryBuilder = customQuery(query, {
+  args: {  },
+  input: async (ctx, args, { role }: { role: "admin" | "user" }) => {
+    const user = await getUser(ctx);
+    if (role === "admin" && user.role !== "admin") {
+      throw new Error("You are not an admin");
+    }
+    if (role === "user" && !user) {
+      throw new Error("You must be logged in to access this query");
+    }
+    return { ctx: { user }, args: {} };
+  }
+});
+
+const myAdminQuery = myQueryBuilder({
+  role: "admin",
+  args: { },
+  handler: async (ctx, args) => {
     // ...
   },
 });

--- a/packages/convex-helpers/README.md
+++ b/packages/convex-helpers/README.md
@@ -81,7 +81,7 @@ You can take in extra arguments to a custom function by specifying the type of a
 
 ```ts
 const myQueryBuilder = customQuery(query, {
-  args: {  },
+  args: {},
   input: async (ctx, args, { role }: { role: "admin" | "user" }) => {
     const user = await getUser(ctx);
     if (role === "admin" && user.role !== "admin") {
@@ -91,12 +91,12 @@ const myQueryBuilder = customQuery(query, {
       throw new Error("You must be logged in to access this query");
     }
     return { ctx: { user }, args: {} };
-  }
+  },
 });
 
 const myAdminQuery = myQueryBuilder({
   role: "admin",
-  args: { },
+  args: {},
   handler: async (ctx, args) => {
     // ...
   },

--- a/packages/convex-helpers/server/customFunctions.test.ts
+++ b/packages/convex-helpers/server/customFunctions.test.ts
@@ -360,6 +360,22 @@ export const outerRemoves = outerRemover({
 });
 
 /**
+ * Adding extra args to `input`
+ */
+const extraArgQueryBuilder = customQuery(query, {
+  args: { a: v.string() },
+  input: async (_ctx, args, { extraArg }: { extraArg: string }) => ({ ctx: {extraArg}, args }),
+});
+export const extraArgQuery = extraArgQueryBuilder({
+  args: {},
+  extraArg: "foo",
+  handler: async (ctx, args) => {
+    return { ctxA: ctx.extraArg };
+  },
+});
+queryMatches(extraArgQuery, {}, { ctxA: "foo" });
+
+/**
  * Test helpers
  */
 function queryMatches<
@@ -388,6 +404,7 @@ const testApi: ApiFromModules<{
     create: typeof create;
     outerAdds: typeof outerAdds;
     outerRemoves: typeof outerRemoves;
+    extraArgQuery: typeof extraArgQuery;
   };
 }>["fns"] = anyApi["customFunctions.test"] as any;
 
@@ -567,5 +584,14 @@ describe("nested custom functions", () => {
     await expect(() =>
       t.query(testApi.outerAdds, { a: 3 as any, outer: "" }),
     ).rejects.toThrow("Validator error: Expected `string`");
+  });
+});
+
+describe("extra args", () => {
+  test("add extra args", async () => {
+    const t = convexTest(schema, modules);
+    expect(await t.query(testApi.extraArgQuery, { a: "foo" })).toMatchObject({
+      ctxA: "foo",
+    });
   });
 });

--- a/packages/convex-helpers/server/customFunctions.test.ts
+++ b/packages/convex-helpers/server/customFunctions.test.ts
@@ -364,7 +364,10 @@ export const outerRemoves = outerRemover({
  */
 const extraArgQueryBuilder = customQuery(query, {
   args: { a: v.string() },
-  input: async (_ctx, args, { extraArg }: { extraArg: string }) => ({ ctx: {extraArg}, args }),
+  input: async (_ctx, args, { extraArg }: { extraArg: string }) => ({
+    ctx: { extraArg },
+    args,
+  }),
 });
 export const extraArgQuery = extraArgQueryBuilder({
   args: {},

--- a/packages/convex-helpers/server/customFunctions.test.ts
+++ b/packages/convex-helpers/server/customFunctions.test.ts
@@ -147,6 +147,30 @@ customAction(
   customCtx((ctx) => ({})),
 ) satisfies typeof action;
 
+customQuery({} as any, {
+  args: {},
+  input: async () => ({
+    ctx: {},
+    args: {},
+  }),
+}) satisfies typeof query;
+
+customMutation(mutation, {
+  args: {},
+  input: async () => ({
+    ctx: {},
+    args: {},
+  }),
+}) satisfies typeof mutation;
+
+customAction(action, {
+  args: {},
+  input: async () => ({
+    ctx: {},
+    args: {},
+  }),
+}) satisfies typeof action;
+
 /**
  * Testing custom function modifications.
  */

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -471,7 +471,11 @@ export type CustomBuilder<
             ctx: Overwrite<InputCtx, ModCtx>,
             ...args: ArgsForHandlerType<OneOrZeroArgs, ModMadeArgs>
           ) => ReturnValue;
-        } & ExtraArgs)
+        } & {
+          [key in keyof ExtraArgs as key extends "args" | "returns" | "handler"
+            ? never
+            : key]: ExtraArgs[key];
+        })
       | {
           (
             ctx: Overwrite<InputCtx, ModCtx>,
@@ -505,4 +509,4 @@ export type CustomCtx<Builder> =
     ? Overwrite<InputCtx, ModCtx>
     : never;
 
-type Overwrite<T, U> = Omit<T, keyof U> & U;
+type Overwrite<T, U> = keyof U extends never ? T : Omit<T, keyof U> & U;

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -72,12 +72,13 @@ export type Mod<
 export function customCtx<
   InCtx extends Record<string, any>,
   OutCtx extends Record<string, any>,
+  ExtraArgs extends Record<string, any> = {},
 >(
-  mod: (original: InCtx) => Promise<OutCtx> | OutCtx,
-): Mod<InCtx, {}, OutCtx, {}> {
+  mod: (original: InCtx, extra: ExtraArgs) => Promise<OutCtx> | OutCtx,
+): Mod<InCtx, {}, OutCtx, {}, ExtraArgs> {
   return {
     args: {},
-    input: async (ctx) => ({ ctx: await mod(ctx), args: {} }),
+    input: async (ctx, _, extra) => ({ ctx: await mod(ctx, extra), args: {} }),
   };
 }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Now you can specify extra parameters at the function definition site and use them in the customFunction builder

```ts
const myQueryBuilder = customQuery(query, {
  args: {  },
  input: async (ctx, args, { role }: { role: "admin" | "user" }) => {
    const user = await getUser(ctx);
    if (role === "admin" && user.role !== "admin") {
      throw new Error("You are not an admin");
    }
    if (role === "user" && !user) {
      throw new Error("You must be logged in to access this query");
    }
    return { ctx: { user }, args: {} };
  }
});

const myAdminQuery = myQueryBuilder({
  role: "admin",
  args: { },
  handler: async (ctx, args) => {
    // ...
  },
});
```

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
