### PR TITLE
feat(crud): Add support for union types and complex objects

### DIFF
--- a/packages/convex-helpers/server/crud.test.ts
+++ b/packages/convex-helpers/server/crud.test.ts
@@ -12,6 +12,7 @@ import { v } from "convex/values";
 import { internalQueryGeneric, internalMutationGeneric } from "convex/server";
 import { modules } from "./setup.test.js";
 import { customCtx, customMutation, customQuery } from "./customFunctions.js";
+import { doc } from "../validators.js";
 
 const ExampleFields = {
   foo: v.string(),
@@ -356,6 +357,7 @@ test("complex object - partial updates", async () => {
     city: "New City",
     country: "New Country",
   });
+
 
   // Update array
   await t.mutation(complexTestApi.complexUpdate, {


### PR DESCRIPTION
## feat(crud): Add support for union types and complex objects

### **What Changed**
Enhanced the `crud()` function to properly support union types and complex nested objects with comprehensive test coverage.

###  **Technical Implementation**

#### **Fixed Validator Composition**
create a new validator with fields that are recursively made optional. This enables the removal of the validator.kind must be object condition.

#### **New Recursive Validator Utilities**
- **`makeOptional`** - Makes all fields optional for update patches
- **`makeSystemFieldsOptional`** - Adds optional system fields for create operations

Both functions recursively handle:
- Objects → Field-level transformations
- Unions → Applied to each member
- Records → Applied to value types
- Others → Optional wrapping

###  **Test Coverage**
Added **9 new test cases** covering:

**Union Tables**
- User type: `{type: "user", name: string, email: string}`
- Admin type: `{type: "admin", name: string, permissions: string[]}`
- Guest type: `{type: "guest", sessionId: string}`

**Complex Objects**
- Nested objects with arrays and optional fields
- Partial updates with proper validation
- Optional field handling

**Edge Cases**
- Pagination with cursors
- Delete operations returning documents
- Non-existent document handling

###  **Benefits**
Enables CRUD operations with any table schema including polymorphic data, complex nested structures, and mixed validation scenarios.