### PR TITLE
Fix incorrect type inference: ensure ZodString instead of generic ZodType<string> on convexToZod function types

### DIFF
--- a/packages/convex-helpers/server/zod.test.ts
+++ b/packages/convex-helpers/server/zod.test.ts
@@ -833,6 +833,9 @@ test("convexToZod complex types", () => {
 
   const recordValidator = convexToZod(v.record(v.string(), v.number()));
   expect(recordValidator.constructor.name).toBe("ZodRecord");
+
+  const optionalValidator = convexToZod(v.optional(v.string()));
+  expect(optionalValidator.constructor.name).toBe("ZodOptional");
 });
 
 test("convexToZodFields", () => {


### PR DESCRIPTION
## What This PR Does

This PR fixes an issue where the inferred type of a Zod schema is too generic (`ZodType<string, ZodTypeDef, string>`), which prevents chaining string-specific methods such as `.min()`, `.email()`, etc.

## Problem

When conditionally constructing a schema, the inferred type ends up being the generic `ZodType<string, ZodTypeDef, string>` instead of the more specific `ZodString`. As a result, methods like `.min()` are not recognized by TypeScript:


Closes #671 

I have read the CLA Document and I hereby sign the CLA.