### PR TITLE
fix(triggers): Make DatabaseWriterWithTriggers methods enumerable for…

### DIFF
--- a/packages/convex-helpers/server/triggers.ts
+++ b/packages/convex-helpers/server/triggers.ts
@@ -171,6 +171,14 @@ export class DatabaseWriterWithTriggers<
     this.#triggers = triggers;
     this.#isWithinTrigger = isWithinTrigger;
     this.system = innerDb.system;
+      // Make methods enumerable by assigning them as instance properties
+    this.get = this.get.bind(this);
+    this.query = this.query.bind(this);
+    this.normalizeId = this.normalizeId.bind(this);
+    this.insert = this.insert.bind(this);
+    this.patch = this.patch.bind(this);
+    this.replace = this.replace.bind(this);
+    this.delete = this.delete.bind(this);
   }
 
   async insert<TableName extends TableNamesInDataModel<DataModel>>(


### PR DESCRIPTION
… spreading

The methods of `DatabaseWriterWithTriggers` were not enumerable, preventing them from being included when the `db` context was spread (e.g., `{...ctx.db}`). This caused issues when attempting to wrap or log the context in downstream middleware.

By explicitly binding and assigning these methods as instance properties in the constructor, they become enumerable. This ensures compatibility with operations like object spreading, matching the expected behavior of the original Convex `db` object.

This change specifically addresses `get`, `query`, `normalizeId`, `insert`, `patch`, `replace`, and `delete` methods.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
