### PR TITLE
export cors http router 

### DIFF
--- a/packages/convex-helpers/server/cors.ts
+++ b/packages/convex-helpers/server/cors.ts
@@ -81,14 +81,22 @@ export type CorsConfig = {
   debug?: boolean;
 };
 
-type RouteSpecWithCors = RouteSpec & CorsConfig;
+export type RouteSpecWithCors = RouteSpec & CorsConfig;
+
+/**
+* An HttpRouter with built in cors support.
+*/
+export type CorsHttpRouter = {
+  http: HttpRouter
+  route: (routeSpec: RouteSpecWithCors): void;
+};
 
 /**
  * Factory function to create a router that adds CORS support to routes.
  * @param allowedOrigins An array of allowed origins for CORS.
  * @returns A function to use instead of http.route when you want CORS.
  */
-export const corsRouter = (http: HttpRouter, corsConfig?: CorsConfig) => {
+export const corsRouter = (http: HttpRouter, corsConfig?: CorsConfig): CorsHttpRouter => {
   const allowedExactMethodsByPath: Map<string, Set<string>> = new Map();
   const allowedPrefixMethodsByPath: Map<string, Set<string>> = new Map();
   return {


### PR DESCRIPTION
export cors router types

<!-- Describe your PR here. -->
The current implementation of the cors helper does not export the the RouteSpecWithCors type. 

This change makes it easier to follow the style implemented by

 ```bash
npx @convex-dev/auth
```

when setting up an http router. 

Upon running the command, convex adds a top level http route:

```ts
const http = httpRouter();
auth.addHttpRoutes(http);
```

I'd like to keep my project consistent with this style, thus by exporting the type this will enable the following pattern:
```ts
const http = httpRouter();
const cors = corsRouter(http);
auth.addHttpRoutes(cors.http); // <--- calling cors directly on this  isn't yet possible due to addHttpRoutes being an imported method
// ./convex/resource1.ts
resource1.add(cors);
// ./convex/resource2.ts 
resource2.add(cors);
/// etc...
```

This pattern make it easier for developers to localize the https routes with the relevant resource file in the top level of their `convex` folder.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
