### PR TITLE
fix union types was wrong

### DIFF
--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -1353,9 +1353,26 @@ type ZodFromValidatorBase<V extends GenericValidator> =
                       : z.ZodRecord<z.ZodString, ZodValidatorFromConvex<Value>>
                     : V extends VArray<any, any>
                       ? z.ZodArray<ZodValidatorFromConvex<V["element"]>>
-                      : V extends VUnion<any, any, any, any>
+                      : V extends VUnion<
+                            any,
+                            [
+                              infer A extends GenericValidator,
+                              infer B extends GenericValidator,
+                              ...infer Rest extends GenericValidator[],
+                            ],
+                            any,
+                            any
+                          >
                         ? z.ZodUnion<
-                            [ZodValidatorFromConvex<V["members"][number]>]
+                            [
+                              ZodValidatorFromConvex<A>,
+                              ZodValidatorFromConvex<B>,
+                              ...{
+                                [K in keyof Rest]: ZodValidatorFromConvex<
+                                  Rest[K]
+                                >;
+                              },
+                            ]
                           >
                         : z.ZodTypeAny; // fallback for unknown validators
 


### PR DESCRIPTION
```
const result = v.union(
    v.object({
        kind: v.literal("StringDocument"),
        value: v.string(),
    }),
    v.object({
        kind: v.literal("NumberDocument"),
        value: v.number(),
    }),
);
```

this code should result with comma separated object instead of | (vertical bar) like that👇🏻

```
z.ZodUnion<[z.ZodObject<{
    kind: z.ZodLiteral<"StringDocument">;
    value: z.ZodString;
}, "strip", z.ZodTypeAny, {
    value: string;
    kind: "StringDocument";
}, {
    value: string;
    kind: "StringDocument";
}>, z.ZodObject<{
    kind: z.ZodLiteral<"NumberDocument">;
    value: z.ZodNumber;
}, "strip", z.ZodTypeAny, {
    value: number;
    kind: "NumberDocument";
}, {
    value: number;
    kind: "NumberDocument";
}>]>
```

instead of 

```
z.ZodUnion<[z.ZodObject<{
    kind: z.ZodLiteral<"StringDocument">;
    value: z.ZodString;
}, "strip", z.ZodTypeAny, {
    value: string;
    kind: "StringDocument";
}, {
    value: string;
    kind: "StringDocument";
}> | z.ZodObject<{
    kind: z.ZodLiteral<"NumberDocument">;
    value: z.ZodNumber;
}, "strip", z.ZodTypeAny, {
    value: number;
    kind: "NumberDocument";
}, {
    value: number;
    kind: "NumberDocument";
}>]>
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
