### PR TITLE
Use compareValues from convex-helpers

### DIFF
--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unexpected-multiline */
 import type { Value } from "convex/values";
-import { convexToJson, compareValues, jsonToConvex } from "convex/values";
+import { convexToJson, jsonToConvex } from "convex/values";
 import type {
   DataModelFromSchemaDefinition,
   DocumentByInfo,
@@ -21,6 +21,7 @@ import type {
   SystemDataModel,
   TableNamesInDataModel,
 } from "convex/server";
+import { compareValues } from "./compare.js";
 
 export type IndexKey = (Value | undefined)[];
 


### PR DESCRIPTION
This fixes an issue with people using older convex NPM versions that don't include compareValues