### PR TITLE
Export QueryStream

### DIFF
--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -214,7 +214,7 @@ type GenericStreamItem = NonNullable<unknown>;
 /**
  * A "QueryStream" is an async iterable of query results, ordered by indexed fields.
  */
-abstract class QueryStream<T extends GenericStreamItem>
+export abstract class QueryStream<T extends GenericStreamItem>
   implements GenericOrderedQuery<T>
 {
   // Methods that subclasses must implement so OrderedQuery can be implemented.


### PR DESCRIPTION
<!-- Describe your PR here. -->

I'm creating Effect wrappers around Convex and ConvexHelpers, and while working on the stream helpers, I struggled a lot with TypeScript because I don't have access to the type of the internal `QueryStream` class. If it's ok to export it that would help me avoid having to do castings to `any` 😅.
(If not, that's fine)

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
