### PR TITLE
Update the Convex peer dependency

### DIFF
--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -156,7 +156,7 @@
   "homepage": "https://github.com/get-convex/convex-helpers/tree/main/packages/convex-helpers/README.md",
   "peerDependencies": {
     "@standard-schema/spec": "^1.0.0",
-    "convex": "^1.13.0",
+    "convex": "^1.24.0",
     "hono": "^4.0.5",
     "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
     "typescript": "^5.5",


### PR DESCRIPTION
`convex-helpers` now uses `compareValues` from `convex/server`, which was introduced [in `convex` 1.24.0](https://github.com/get-convex/convex-js/blob/main/CHANGELOG.md#1240). Let’s bump the peer dependency requirement to avoid invalid installations.