### PR TITLE
Ian/custom args fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11418,7 +11418,7 @@
     },
     "packages/convex-helpers/dist": {
       "name": "convex-helpers",
-      "version": "0.1.101-alpha.0",
+      "version": "0.1.101",
       "license": "Apache-2.0",
       "bin": {
         "convex-helpers": "bin.cjs"

--- a/packages/convex-helpers/CHANGELOG.md
+++ b/packages/convex-helpers/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## 0.1.101 alpha
 
 - Improved Zod union type (credit:Firephoenix25)
+- Fixes zCustom\* function type inference regression
+- Adds a helper function `addFieldsToValidator` which recursively adds fields
+  to either a `{ key: v.string() }`, a `v.object(..)`, or `v.union(...` of objects/unions.
+- Tightens the types when not using extra args, so it catches typos
+- Removes the long-deprecated "output" argument (use `returns` instead)- Improved Zod union type (credit:Firephoenix25)
+- Bumps the Convex peer dependency as we rely on compareValues (credit:nicolas)
+- Exports types for QueryStream
 
 ## 0.1.100
 

--- a/packages/convex-helpers/CHANGELOG.md
+++ b/packages/convex-helpers/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.101 alpha
+## 0.1.101
 
 - Improved Zod union type (credit:Firephoenix25)
 - Fixes zCustom\* function type inference regression

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-helpers",
-  "version": "0.1.101-alpha.0",
+  "version": "0.1.101",
   "description": "A collection of useful code to complement the official convex package.",
   "type": "module",
   "bin": {

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -76,10 +76,15 @@ import { addFieldsToValidator } from "../validators.js";
  * has access to resources created during input processing via closure.
  */
 export type Customization<
+  // The ctx object from the original function.
   Ctx extends Record<string, any>,
+  // The validators for the args the customization function consumes.
   CustomArgsValidator extends PropertyValidators,
+  // The ctx object produced: a patch applied to the original ctx.
   CustomCtx extends Record<string, any>,
+  // The args produced by the customization function.
   CustomMadeArgs extends Record<string, any>,
+  // Extra args that are passed to the input function.
   ExtraArgs extends Record<string, any> = Record<string, any>,
 > = {
   args: CustomArgsValidator;
@@ -155,13 +160,14 @@ export function customCtxAndArgs<
   CustomMadeArgs,
   ExtraArgs
 > {
+  // This is already the right type. This function just helps you define it.
   return objectWithArgsAndInput;
 }
 
 /**
  * A helper for defining a Customization when your mod doesn't need to add or remove
  * anything from args.
- * @param mod A function that defines how to modify the ctx.
+ * @param modifyCtx A function that defines how to modify the ctx.
  * @returns A ctx delta to be applied to the original ctx.
  */
 export function customCtx<

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -350,7 +350,7 @@ export function customMutation<
   ExtraArgs extends Record<string, any> = Record<string, any>,
 >(
   mutation: MutationBuilder<DataModel, Visibility>,
-  mod: Customization<
+  customization: Customization<
     GenericMutationCtx<DataModel>,
     CustomArgsValidator,
     CustomCtx,
@@ -358,7 +358,7 @@ export function customMutation<
     ExtraArgs
   >,
 ) {
-  return customFnBuilder(mutation, mod) as CustomBuilder<
+  return customFnBuilder(mutation, customization) as CustomBuilder<
     "mutation",
     CustomArgsValidator,
     CustomCtx,
@@ -430,7 +430,7 @@ export function customMutation<
  *
  * @param action The action to be modified. Usually `action` or `internalAction`
  *   from `_generated/server`.
- * @param mod The modifier to be applied to the action, changing ctx and args.
+ * @param customization The modifier to be applied to the action, changing ctx and args.
  * @returns A new action builder to define queries with modified ctx and args.
  */
 export function customAction<
@@ -442,7 +442,7 @@ export function customAction<
   ExtraArgs extends Record<string, any> = Record<string, any>,
 >(
   action: ActionBuilder<DataModel, Visibility>,
-  mod: Customization<
+  customization: Customization<
     GenericActionCtx<DataModel>,
     CustomArgsValidator,
     CustomCtx,
@@ -458,7 +458,7 @@ export function customAction<
   Visibility,
   ExtraArgs
 > {
-  return customFnBuilder(action, mod) as CustomBuilder<
+  return customFnBuilder(action, customization) as CustomBuilder<
     "action",
     CustomArgsValidator,
     CustomCtx,

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -175,7 +175,7 @@ export function customCtx<
   OutCtx extends Record<string, any>,
   ExtraArgs extends Record<string, any> = Record<string, any>,
 >(
-  mod: (original: InCtx, extra: ExtraArgs) => Promise<OutCtx> | OutCtx,
+  modifyCtx: (original: InCtx, extra: ExtraArgs) => Promise<OutCtx> | OutCtx,
 ): Customization<
   InCtx,
   Record<string, never>,
@@ -185,7 +185,10 @@ export function customCtx<
 > {
   return {
     args: {},
-    input: async (ctx, _, extra) => ({ ctx: await mod(ctx, extra), args: {} }),
+    input: async (ctx, _, extra) => ({
+      ctx: await modifyCtx(ctx, extra),
+      args: {},
+    }),
   };
 }
 

--- a/packages/convex-helpers/server/customFunctions.ts
+++ b/packages/convex-helpers/server/customFunctions.ts
@@ -265,7 +265,7 @@ export function customQuery<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
-  ExtraArgs extends Record<string, any> = Record<string, any>,
+  ExtraArgs extends Record<string, any> = object,
 >(
   query: QueryBuilder<DataModel, Visibility>,
   customization: Customization<
@@ -353,7 +353,7 @@ export function customMutation<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
-  ExtraArgs extends Record<string, any> = Record<string, any>,
+  ExtraArgs extends Record<string, any> = object,
 >(
   mutation: MutationBuilder<DataModel, Visibility>,
   customization: Customization<
@@ -445,7 +445,7 @@ export function customAction<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
-  ExtraArgs extends Record<string, any> = Record<string, any>,
+  ExtraArgs extends Record<string, any> = object,
 >(
   action: ActionBuilder<DataModel, Visibility>,
   customization: Customization<

--- a/packages/convex-helpers/server/zod.test.ts
+++ b/packages/convex-helpers/server/zod.test.ts
@@ -617,7 +617,7 @@ test("zod output compliance", async () => {
   // number should fail
   await expect(() =>
     t.query(testApi.zodOutputCompliance, {
-      optionalString: 1,
+      optionalString: 1 as any,
     }),
   ).rejects.toThrow();
 });

--- a/packages/convex-helpers/server/zod.test.ts
+++ b/packages/convex-helpers/server/zod.test.ts
@@ -4,6 +4,7 @@ import type {
   ApiFromModules,
   RegisteredQuery,
   DefaultFunctionArgs,
+  FunctionReference,
 } from "convex/server";
 import { defineTable, defineSchema, queryGeneric, anyApi } from "convex/server";
 import type { Equals } from "../index.js";
@@ -361,6 +362,7 @@ const testApi: ApiFromModules<{
     addC: typeof addC;
     addCU: typeof addCU;
     addCU2: typeof addCU2;
+    addCtxWithExistingArg: typeof addCtxWithExistingArg;
     add: typeof add;
     addUnverified: typeof addUnverified;
     addUnverified2: typeof addUnverified2;
@@ -642,6 +644,32 @@ describe("zod functions", () => {
     expect(await t.query(testApi.addCU2, {})).toMatchObject({
       ctxA: "hi",
     });
+  });
+
+  test("add ctx with existing arg", async () => {
+    const t = convexTest(schema, modules);
+    expect(
+      await t.query(testApi.addCtxWithExistingArg, { b: "foo" }),
+    ).toMatchObject({
+      ctxA: "hi",
+      argB: "foo",
+    });
+    expectTypeOf(testApi.addCtxWithExistingArg).toExtend<
+      FunctionReference<
+        "query",
+        "public",
+        { b: string },
+        { ctxA: string; argB: string }
+      >
+    >();
+    expectTypeOf<
+      FunctionReference<
+        "query",
+        "public",
+        { b: string },
+        { ctxA: string; argB: string }
+      >
+    >().toExtend<typeof testApi.addCtxWithExistingArg>();
   });
 
   test("add args", async () => {

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -415,42 +415,47 @@ function customFnBuilder(
 type OneArgArray<ArgsObject extends DefaultFunctionArgs = DefaultFunctionArgs> =
   [ArgsObject];
 
-export type ArgsArray = OneArgArray | [];
 
-export type ReturnValueForOptionalZodValidator<
+// Copied from convex/src/server/api.ts since they aren't exported
+type NullToUndefinedOrNull<T> = T extends null ? T | undefined | void : T;
+type Returns<T> =
+  | Promise<NullToUndefinedOrNull<T>>
+  | NullToUndefinedOrNull<T>;
+
+// The return value before it's been validated: returned by the handler
+type ReturnValueInput<
   ReturnsValidator extends z.ZodTypeAny | ZodValidator | void,
 > = [ReturnsValidator] extends [z.ZodTypeAny]
-  ? z.input<ReturnsValidator> | Promise<z.input<ReturnsValidator>>
+  ? Returns<z.input<ReturnsValidator>>
   : [ReturnsValidator] extends [ZodValidator]
-    ?
-        | z.input<z.ZodObject<ReturnsValidator>>
-        | Promise<z.input<z.ZodObject<ReturnsValidator>>>
+    ? Returns<z.input<z.ZodObject<ReturnsValidator>>>
     : any;
 
-export type OutputValueForOptionalZodValidator<
+// The return value after it's been validated: returned to the client
+type ReturnValueOutput<
   ReturnsValidator extends z.ZodTypeAny | ZodValidator | void,
 > = [ReturnsValidator] extends [z.ZodTypeAny]
-  ? z.output<ReturnsValidator> | Promise<z.output<ReturnsValidator>>
+  ? Returns<z.output<ReturnsValidator>>
   : [ReturnsValidator] extends [ZodValidator]
-    ?
-        | z.output<z.ZodObject<ReturnsValidator>>
-        | Promise<z.output<z.ZodObject<ReturnsValidator>>>
+    ? Returns<z.output<z.ZodObject<ReturnsValidator>>>
     : any;
 
-export type ArgsArrayForOptionalValidator<
-  ArgsValidator extends ZodValidator | z.ZodObject<any> | void,
-> = [ArgsValidator] extends [ZodValidator]
-  ? [z.output<z.ZodObject<ArgsValidator>>]
-  : [ArgsValidator] extends [z.ZodObject<any>]
-    ? [z.output<ArgsValidator>]
-    : ArgsArray;
-export type DefaultArgsForOptionalValidator<
-  ArgsValidator extends ZodValidator | z.ZodObject<any> | void,
-> = [ArgsValidator] extends [ZodValidator]
-  ? [z.output<z.ZodObject<ArgsValidator>>]
-  : [ArgsValidator] extends [z.ZodObject<any>]
-    ? [z.output<ArgsValidator>]
+// The args before they've been validated: passed from the client
+type ArgsInput<ArgsValidator extends ZodValidator | z.ZodObject<any> | void> = [
+  ArgsValidator,
+] extends [z.ZodObject<any>]
+  ? [z.input<ArgsValidator>]
+  : [ArgsValidator] extends [ZodValidator]
+    ? [z.input<z.ZodObject<ArgsValidator>>]
     : OneArgArray;
+
+// The args after they've been validated: passed to the handler
+type ArgsOutput<ArgsValidator extends ZodValidator | z.ZodObject<any> | void> =
+  [ArgsValidator] extends [z.ZodObject<any>]
+    ? [z.output<ArgsValidator>]
+    : [ArgsValidator] extends [ZodValidator]
+      ? [z.output<z.ZodObject<ArgsValidator>>]
+      : OneArgArray;
 
 type Overwrite<T, U> = Omit<T, keyof U> & U;
 
@@ -466,6 +471,16 @@ type Expand<ObjectType extends Record<any, any>> =
         [Key in keyof ObjectType]: ObjectType[Key];
       }
     : never;
+
+type ArgsForHandlerType<
+  OneOrZeroArgs extends [] | [Record<string, any>],
+  CustomMadeArgs extends Record<string, any>,
+> =
+  CustomMadeArgs extends Record<string, never>
+    ? OneOrZeroArgs
+    : OneOrZeroArgs extends [infer A]
+      ? [Expand<A & CustomMadeArgs>]
+      : [CustomMadeArgs];
 
 /**
  * A builder that customizes a Convex function, whether or not it validates
@@ -484,10 +499,11 @@ export type CustomBuilder<
   <
     ArgsValidator extends ZodValidator | z.ZodObject<any> | void,
     ReturnsZodValidator extends z.ZodTypeAny | ZodValidator | void = void,
-    ReturnValue extends
-      ReturnValueForOptionalZodValidator<ReturnsZodValidator> = any,
-    OneOrZeroArgs extends
-      ArgsArrayForOptionalValidator<ArgsValidator> = DefaultArgsForOptionalValidator<ArgsValidator>,
+    ReturnValue extends ReturnValueInput<ReturnsZodValidator> = any,
+    // Note: this differs from customFunctions.ts b/c we don't need to track
+    // the exact args to match the standard builder types. For zod we don't
+    // try to ever pass a custom function as a builder to another custom
+    // function, so we can be looser here.
   >(
     func:
       | ({
@@ -497,63 +513,53 @@ export type CustomBuilder<
           args?: ArgsValidator;
           handler: (
             ctx: Overwrite<InputCtx, CustomCtx>,
-            ...args: OneOrZeroArgs extends [infer A]
-              ? [Expand<A & CustomMadeArgs>]
-              : [CustomMadeArgs]
+            ...args: ArgsForHandlerType<
+              ArgsOutput<ArgsValidator>,
+              CustomMadeArgs
+            >
           ) => ReturnValue;
+          /**
+           * Validates the value returned by the function.
+           * Note: you can't pass an object directly without wrapping it
+           * in `z.object()`.
+           */
+          returns?: ReturnsZodValidator;
           /**
            * If true, the function will not be validated by Convex,
            * in case you're seeing performance issues with validating twice.
            */
           skipConvexValidation?: boolean;
-        } & (
-          | {
-              /**
-               * @deprecated Use `returns` instead.
-               * Older version of `returns` that does not also do convex
-               * validation on the output value of the function.
-               * Note: you can't pass an object directly without wrapping it
-               * in `z.object()`.
-               */
-              output?: ReturnsZodValidator;
-            }
-          | {
-              /**
-               * Validates the value returned by the function.
-               * Note: you can't pass an object directly without wrapping it
-               * in `z.object()`.
-               */
-              returns?: ReturnsZodValidator;
-            }
-        ))
+        } & {
+          [key in keyof ExtraArgs as key extends
+            | "args"
+            | "handler"
+            | "skipConvexValidation"
+            | "returns"
+            ? never
+            : key]: ExtraArgs[key];
+        })
       | {
           (
             ctx: Overwrite<InputCtx, CustomCtx>,
-            ...args: OneOrZeroArgs extends [infer A]
-              ? [Expand<A & CustomMadeArgs>]
-              : [CustomMadeArgs]
+            ...args: ArgsForHandlerType<
+              ArgsOutput<ArgsValidator>,
+              CustomMadeArgs
+            >
           ): ReturnValue;
         },
   ): Registration<
     FuncType,
     Visibility,
     ArgsArrayToObject<
-      [ArgsValidator] extends [ZodValidator]
-        ? [
-            Expand<
-              z.input<z.ZodObject<ArgsValidator>> &
-                ObjectType<CustomArgsValidator>
-            >,
-          ]
-        : [ArgsValidator] extends [z.ZodObject<any>]
-          ? [Expand<z.input<ArgsValidator> & ObjectType<CustomArgsValidator>>]
-          : OneOrZeroArgs extends [infer A]
-            ? [Expand<A & ObjectType<CustomArgsValidator>>]
-            : [ObjectType<CustomArgsValidator>]
+      CustomArgsValidator extends Record<string, never>
+        ? ArgsInput<ArgsValidator>
+        : ArgsInput<ArgsValidator> extends [infer A]
+          ? [Expand<A & ObjectType<CustomArgsValidator>>]
+          : [ObjectType<CustomArgsValidator>]
     >,
     ReturnsZodValidator extends void
       ? ReturnValue
-      : OutputValueForOptionalZodValidator<ReturnsZodValidator>
+      : ReturnValueOutput<ReturnsZodValidator>
   >;
 };
 

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -415,12 +415,9 @@ function customFnBuilder(
 type OneArgArray<ArgsObject extends DefaultFunctionArgs = DefaultFunctionArgs> =
   [ArgsObject];
 
-
 // Copied from convex/src/server/api.ts since they aren't exported
 type NullToUndefinedOrNull<T> = T extends null ? T | undefined | void : T;
-type Returns<T> =
-  | Promise<NullToUndefinedOrNull<T>>
-  | NullToUndefinedOrNull<T>;
+type Returns<T> = Promise<NullToUndefinedOrNull<T>> | NullToUndefinedOrNull<T>;
 
 // The return value before it's been validated: returned by the handler
 type ReturnValueInput<

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -136,7 +136,7 @@ export function zCustomQuery<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
-  ExtraArgs extends Record<string, any> = Record<string, any>,
+  ExtraArgs extends Record<string, any> = object,
 >(
   query: QueryBuilder<DataModel, Visibility>,
   customization: Customization<
@@ -218,7 +218,7 @@ export function zCustomMutation<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
-  ExtraArgs extends Record<string, any> = Record<string, any>,
+  ExtraArgs extends Record<string, any> = object,
 >(
   mutation: MutationBuilder<DataModel, Visibility>,
   customization: Customization<
@@ -300,7 +300,7 @@ export function zCustomAction<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
-  ExtraArgs extends Record<string, any> = Record<string, any>,
+  ExtraArgs extends Record<string, any> = object,
 >(
   action: ActionBuilder<DataModel, Visibility>,
   customization: Customization<

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -70,6 +70,7 @@ export type ZCustomCtx<Builder> =
     infer CustomCtx,
     any,
     infer InputCtx,
+    any,
     any
   >
     ? Overwrite<InputCtx, CustomCtx>
@@ -135,13 +136,15 @@ export function zCustomQuery<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
+  ExtraArgs extends Record<string, any> = Record<string, any>,
 >(
   query: QueryBuilder<DataModel, Visibility>,
   customization: Customization<
     GenericQueryCtx<DataModel>,
     CustomArgsValidator,
     CustomCtx,
-    CustomMadeArgs
+    CustomMadeArgs,
+    ExtraArgs
   >,
 ) {
   return customFnBuilder(query, customization) as CustomBuilder<
@@ -150,7 +153,8 @@ export function zCustomQuery<
     CustomCtx,
     CustomMadeArgs,
     GenericQueryCtx<DataModel>,
-    Visibility
+    Visibility,
+    ExtraArgs
   >;
 }
 
@@ -214,13 +218,15 @@ export function zCustomMutation<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
+  ExtraArgs extends Record<string, any> = Record<string, any>,
 >(
   mutation: MutationBuilder<DataModel, Visibility>,
   customization: Customization<
     GenericMutationCtx<DataModel>,
     CustomArgsValidator,
     CustomCtx,
-    CustomMadeArgs
+    CustomMadeArgs,
+    ExtraArgs
   >,
 ) {
   return customFnBuilder(mutation, customization) as CustomBuilder<
@@ -229,7 +235,8 @@ export function zCustomMutation<
     CustomCtx,
     CustomMadeArgs,
     GenericMutationCtx<DataModel>,
-    Visibility
+    Visibility,
+    ExtraArgs
   >;
 }
 
@@ -293,13 +300,15 @@ export function zCustomAction<
   CustomMadeArgs extends Record<string, any>,
   Visibility extends FunctionVisibility,
   DataModel extends GenericDataModel,
+  ExtraArgs extends Record<string, any> = Record<string, any>,
 >(
   action: ActionBuilder<DataModel, Visibility>,
   customization: Customization<
     GenericActionCtx<DataModel>,
     CustomArgsValidator,
     CustomCtx,
-    CustomMadeArgs
+    CustomMadeArgs,
+    ExtraArgs
   >,
 ) {
   return customFnBuilder(action, customization) as CustomBuilder<
@@ -308,13 +317,14 @@ export function zCustomAction<
     CustomCtx,
     CustomMadeArgs,
     GenericActionCtx<DataModel>,
-    Visibility
+    Visibility,
+    ExtraArgs
   >;
 }
 
 function customFnBuilder(
   builder: (args: any) => any,
-  customization: Customization<any, any, any, any>,
+  customization: Customization<any, any, any, any, any>,
 ) {
   // Looking forward to when input / args / ... are optional
   const customInput = customization.input ?? NoOp.input;
@@ -469,6 +479,7 @@ export type CustomBuilder<
   CustomMadeArgs extends Record<string, any>,
   InputCtx,
   Visibility extends FunctionVisibility,
+  ExtraArgs extends Record<string, any>,
 > = {
   <
     ArgsValidator extends ZodValidator | z.ZodObject<any> | void,

--- a/packages/convex-helpers/server/zod.ts
+++ b/packages/convex-helpers/server/zod.ts
@@ -39,6 +39,7 @@ import type {
 import type { Customization, Registration } from "./customFunctions.js";
 import { NoOp } from "./customFunctions.js";
 import { pick } from "../index.js";
+import { addFieldsToValidator } from "../validators.js";
 
 export type ZodValidator = Record<string, z.ZodTypeAny>;
 
@@ -345,10 +346,7 @@ function customFnBuilder(
       }
       const convexValidator = zodToConvexFields(argsValidator);
       return builder({
-        args: {
-          ...convexValidator,
-          ...inputArgs,
-        },
+        args: addFieldsToValidator(convexValidator, inputArgs),
         ...returnValidator,
         handler: async (ctx: any, allArgs: any) => {
           const added = await customInput(


### PR DESCRIPTION
<!-- Describe your PR here. -->

- fixes the regression in 0.1.100 around custom function types in zod functions
- adds a helper function `addFieldsToValidator` which recursively adds fields
  to either a `{ key: v.string() }`, a `v.object(..)`, or `v.union(...` of objects/unions.
- tightens the types when not using extra args, so it catches typos
- add more comments and improve some variable naming
- test for a zod custom function that adds args in custom context and in the fn
- removes the long-deprecated "output" argument (use `returns` instead)

Fixes #708 
<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
