### PR TITLE
fix: make all partial args result in optional arg

### DIFF
--- a/packages/convex-helpers/react/sessions.test.ts
+++ b/packages/convex-helpers/react/sessions.test.ts
@@ -28,6 +28,17 @@ expectTypeOf<
 
 expectTypeOf<
   SessionQueryArgsArray<
+    FunctionReference<
+      "query",
+      "public",
+      { arg?: string; sessionId: SessionId | null },
+      any
+    >
+  >
+>().toEqualTypeOf<[args?: { arg?: string } | "skip"]>();
+
+expectTypeOf<
+  SessionQueryArgsArray<
     FunctionReference<"query", "public", { sessionId: SessionId | null }, any>
   >
 >().toEqualTypeOf<[args?: EmptyObject | "skip" | undefined]>();
@@ -42,6 +53,17 @@ expectTypeOf<
     >
   >
 >().toEqualTypeOf<[{ arg: string }]>();
+
+expectTypeOf<
+  SessionArgsArray<
+    FunctionReference<
+      "mutation",
+      "public",
+      { arg?: string; sessionId: SessionId },
+      any
+    >
+  >
+>().toEqualTypeOf<[args?: { arg?: string }]>();
 
 expectTypeOf<
   SessionArgsArray<

--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -73,23 +73,33 @@ type SessionFunction<
   Args = any,
 > = FunctionReference<T, "public", { sessionId: SessionId } & Args>;
 
+type ArgsWithoutSession<
+  Fn extends SessionFunction<"query" | "mutation" | "action">,
+> = BetterOmit<FunctionArgs<Fn>, "sessionId">;
+
 export type SessionQueryArgsArray<Fn extends SessionFunction<"query">> =
   keyof FunctionArgs<Fn> extends "sessionId"
     ? [args?: EmptyObject | "skip"]
-    : [args: BetterOmit<FunctionArgs<Fn>, "sessionId"> | "skip"];
+    : Partial<ArgsWithoutSession<Fn>> extends ArgsWithoutSession<Fn>
+      ? [args?: ArgsWithoutSession<Fn> | "skip"]
+      : [args: ArgsWithoutSession<Fn> | "skip"];
 
 export type SessionArgsArray<
   Fn extends SessionFunction<"query" | "mutation" | "action">,
 > = keyof FunctionArgs<Fn> extends "sessionId"
   ? [args?: EmptyObject]
-  : [args: BetterOmit<FunctionArgs<Fn>, "sessionId">];
+  : Partial<ArgsWithoutSession<Fn>> extends ArgsWithoutSession<Fn>
+    ? [args?: ArgsWithoutSession<Fn>]
+    : [args: ArgsWithoutSession<Fn>];
 
 export type SessionArgsAndOptions<
   Fn extends SessionFunction<"mutation">,
   Options,
 > = keyof FunctionArgs<Fn> extends "sessionId"
   ? [args?: EmptyObject, options?: Options]
-  : [args: BetterOmit<FunctionArgs<Fn>, "sessionId">, options?: Options];
+  : Partial<ArgsWithoutSession<Fn>> extends ArgsWithoutSession<Fn>
+    ? [args: ArgsWithoutSession<Fn>, options?: Options]
+    : [args: ArgsWithoutSession<Fn>, options?: Options];
 
 type SessionPaginatedQueryFunction<
   Args extends { paginationOpts: PaginationOptions } = {

--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -98,7 +98,7 @@ export type SessionArgsAndOptions<
 > = keyof FunctionArgs<Fn> extends "sessionId"
   ? [args?: EmptyObject, options?: Options]
   : Partial<ArgsWithoutSession<Fn>> extends ArgsWithoutSession<Fn>
-    ? [args: ArgsWithoutSession<Fn>, options?: Options]
+    ? [args?: ArgsWithoutSession<Fn>, options?: Options]
     : [args: ArgsWithoutSession<Fn>, options?: Options];
 
 type SessionPaginatedQueryFunction<


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR makes it so that functions that have all of their args set to optional don't have to pass an empty object to the session query to fix type errors.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
