### PR TITLE
Improve agentic setup for working with TypeScript

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,3 @@
+{
+  "setup-worktree": ["npm ci"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+When doing a task that involves modifying complex TypeScript types, run `npm run typecheck` in the root of the repository to ensure that the types are correct. Do not attempt to run `tsc` manually.


### PR DESCRIPTION
This:

- sets up `.cursor/worktrees.json` to allow me to use [Cursor parallel agents](https://cursor.com/docs/configuration/worktrees) in this repo
- Adds an agent instruction to run `typecheck`. Agents will often try to run `tsc` by themselves. When doing so, they might use the tsconfig.json file that excludes tests, which can lead to false positives.