### PR TITLE
Zod: fix handling of functions that return nothing

### DIFF
--- a/packages/convex-helpers/server/zod3.ts
+++ b/packages/convex-helpers/server/zod3.ts
@@ -394,7 +394,9 @@ function customFnBuilder(
           const ret = await handler(finalCtx, finalArgs);
           // We don't catch the error here. It's a developer error and we
           // don't want to risk exposing the unexpected value to the client.
-          const result = returns ? returns.parse(ret) : ret;
+          const result = returns
+            ? returns.parse(ret === undefined ? null : ret)
+            : ret;
           if (added.onSuccess) {
             await added.onSuccess({ ctx, args, result });
           }
@@ -417,7 +419,9 @@ function customFnBuilder(
         const ret = await handler(finalCtx, finalArgs);
         // We don't catch the error here. It's a developer error and we
         // don't want to risk exposing the unexpected value to the client.
-        const result = returns ? returns.parse(ret) : ret;
+        const result = returns
+          ? returns.parse(ret === undefined ? null : ret)
+          : ret;
         if (added.onSuccess) {
           await added.onSuccess({ ctx, args, result });
         }

--- a/packages/convex-helpers/server/zod4.functions.test.ts
+++ b/packages/convex-helpers/server/zod4.functions.test.ts
@@ -117,6 +117,11 @@ export const testAction = zAction({
   }),
 });
 
+export const returnsNothing = zQuery({
+  handler: async () => {},
+  returns: z.null(),
+});
+
 /**
  * Test transform in query args and return value
  */
@@ -229,6 +234,7 @@ const testApi: ApiFromModules<{
     testQuery: typeof testQuery;
     testMutation: typeof testMutation;
     testAction: typeof testAction;
+    returnsNothing: typeof returnsNothing;
     transform: typeof transform;
     codec: typeof codec;
     myComplexQuery: typeof myComplexQuery;
@@ -298,6 +304,14 @@ describe("zCustomQuery, zCustomMutation, zCustomAction", () => {
           { result: string; length: number }
         >
       >();
+    });
+
+    test("function that returns nothing has a return value of null", async () => {
+      // `undefined` is not a valid Convex value, so functions returning `undefined` actually return `null`.
+      const t = convexTest(schema, modules);
+      const response = await t.query(testApi.returnsNothing, {});
+      expect(response).toEqual(null);
+      expectTypeOf(response).toExtend<null>();
     });
 
     test("README example", async () => {

--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -894,7 +894,9 @@ function customFnBuilder(
           const ret = await handler(finalCtx, finalArgs);
           // We don't catch the error here. It's a developer error and we
           // don't want to risk exposing the unexpected value to the client.
-          const result = returns ? returns.parse(ret) : ret;
+          const result = returns
+            ? returns.parse(ret === undefined ? null : ret)
+            : ret;
           if (added.onSuccess) {
             await added.onSuccess({ ctx, args, result });
           }
@@ -917,7 +919,9 @@ function customFnBuilder(
         const ret = await handler(finalCtx, finalArgs);
         // We don't catch the error here. It's a developer error and we
         // don't want to risk exposing the unexpected value to the client.
-        const result = returns ? returns.parse(ret) : ret;
+        const result = returns
+          ? returns.parse(ret === undefined ? null : ret)
+          : ret;
         if (added.onSuccess) {
           await added.onSuccess({ ctx, args, result });
         }


### PR DESCRIPTION
Since `undefined` is not a valid Convex value, functions that return nothing have a return value of `null` (not `undefined`). The Zod types are already wired correctly (a return validator of `z.null()` is accepted in this case), but we pass `undefined` as a value to Zod, which leads to Zod throwing an error at runtime. This pull request fixes this issue.
