### PR TITLE
fix: call convexToJSON on args being passed to JSON.stringify

### DIFF
--- a/packages/convex-helpers/react.ts
+++ b/packages/convex-helpers/react.ts
@@ -139,7 +139,7 @@ export function makeUseQueryWithStatus(useQueriesHook: typeof useQueries) {
           args,
         },
       };
-    }, [getFunctionName(query), JSON.stringify(args)]);
+    }, [getFunctionName(query), JSON.stringify(convexToJson(args))]);
     const result = useQueriesHook(queries);
     if (args === "skip") {
       return {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Causes a runtime crash without this

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query memoization to properly detect changes in query parameters, ensuring queries re-run when needed and avoid unnecessary re-executions when parameters are structurally equivalent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->