### PR TITLE
fix: guard against non-object values in WeakSet for Zod 4

### DIFF
--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -427,6 +427,11 @@ export function zodToConvex<Z extends zCore.$ZodType>(
   const visited = new WeakSet<zCore.$ZodType>();
 
   function zodToConvexInner(validator: zCore.$ZodType): GenericValidator {
+    // Guard: Ensure validator is an object before using WeakSet
+    if (typeof validator !== "object" || validator === null) {
+      return v.any();
+    }
+    
     // Circular validator definitions are not supported by Convex validators,
     // so we use v.any() when there is a cycle.
     if (visited.has(validator)) {
@@ -517,6 +522,11 @@ export function zodOutputToConvex<Z extends zCore.$ZodType>(
   const visited = new WeakSet<zCore.$ZodType>();
 
   function zodOutputToConvexInner(validator: zCore.$ZodType): GenericValidator {
+    // Guard: Ensure validator is an object before using WeakSet
+    if (typeof validator !== "object" || validator === null) {
+      return v.any();
+    }
+    
     // Circular validator definitions are not supported by Convex validators,
     // so we use v.any() when there is a cycle.
     if (visited.has(validator)) {


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes #891
Add type guard to prevent 'Invalid value used in weak set' error during esbuild static analysis. The WeakSet.add() method only accepts objects, but during static analysis, some values passed to zodToConvex and zodOutputToConvex may be primitives or null.

This fix adds a guard check before using WeakSet operations to ensure the validator is an object, returning v.any() as a fallback for non-object values.

Fixes the issue where mutations using zCustomMutation with Zod 4 schemas fail during npx convex dev/deploy with 'Invalid value used in weak set' error.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
