### PR TITLE
allow undefined values for keys in records and unknown keys in objects

### DIFF
--- a/packages/convex-helpers/validators.test.ts
+++ b/packages/convex-helpers/validators.test.ts
@@ -1,8 +1,57 @@
 import { v } from "convex/values";
 import { describe, expect, test, expectTypeOf } from "vitest";
-import { vRequired, type VRequired } from "./validators.js";
+import { vRequired, type VRequired, validate, parse } from "./validators.js";
 import type { Equals } from "./index.js";
 import type { Validator } from "convex/values";
+
+describe("validate with undefined values", () => {
+  test("should skip validation for undefined values in records", () => {
+    const recordValidator = v.record(v.string(), v.string());
+    const valueWithUndefined = {
+      validKey: "validValue",
+      undefinedKey: undefined,
+    };
+
+    // Should not throw because undefined values get stripped
+    expect(validate(recordValidator, valueWithUndefined, { throw: true })).toBe(
+      true,
+    );
+  });
+
+  test("should skip validation for undefined values in objects with and without allowUnknownFields", () => {
+    const objectValidator = v.object({ knownField: v.string() });
+    const valueWithUndefinedUnknown = {
+      knownField: "value",
+      unknownField: undefined,
+    };
+
+    // Should not throw because undefined values get stripped
+    expect(
+      validate(objectValidator, valueWithUndefinedUnknown, {
+        throw: true,
+        allowUnknownFields: true,
+      }),
+    ).toBe(true);
+    expect(
+      validate(objectValidator, valueWithUndefinedUnknown, {
+        throw: true,
+        allowUnknownFields: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("should strip undefined values from records when using parse", () => {
+    const recordValidator = v.record(v.string(), v.string());
+    const valueWithUndefined = {
+      validKey: "validValue",
+      undefinedKey: undefined,
+    };
+
+    const result = parse(recordValidator, valueWithUndefined);
+    expect(result).toEqual({ validKey: "validValue" });
+    expect("undefinedKey" in result).toBe(false);
+  });
+});
 
 describe("vRequired", () => {
   test("returns required validator unchanged", () => {

--- a/packages/convex-helpers/validators.ts
+++ b/packages/convex-helpers/validators.ts
@@ -757,7 +757,10 @@ export function validate<T extends Validator<any, any, any>>(
         }
         if (!opts?.allowUnknownFields) {
           for (const k of Object.keys(value)) {
-            if (validator.fields[k] === undefined) {
+            if (
+              validator.fields[k] === undefined &&
+              value[k as keyof typeof value] !== undefined
+            ) {
               if (opts?.throw) {
                 throw new ValidationError(
                   "nothing",
@@ -796,6 +799,10 @@ export function validate<T extends Validator<any, any, any>>(
           break;
         }
         for (const [k, fieldValue] of Object.entries(value)) {
+          // Skip validation for undefined values as they will be stripped out
+          if (fieldValue === undefined) {
+            continue;
+          }
           valid = validate(validator.key, k, {
             ...opts,
             _pathPrefix: appendPath(opts, k),
@@ -864,7 +871,9 @@ function stripUnknownFields<T extends Validator<any, any, any>>(
     case "record": {
       const result: Infer<T> = {};
       for (const [k, v] of Object.entries(value)) {
-        result[k] = stripUnknownFields(validator.value, v);
+        if (v !== undefined) {
+          result[k] = stripUnknownFields(validator.value, v);
+        }
       }
       return result;
     }


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `validate` and `parse` functions are now available for enhanced validation operations.

* **Improvements**
  * Undefined values are now properly handled during validation—undefined fields are skipped and undefined keys are stripped from parsed results. Unknown field validation correctly handles undefined entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->