### PR TITLE
fix(cors): address bugs in allow all origin handling

### DIFF
--- a/packages/convex-helpers/server/cors.test.http.ts
+++ b/packages/convex-helpers/server/cors.test.http.ts
@@ -198,4 +198,21 @@ cors.route({
   allowedOrigins: ["http://localhost:3000"],
 });
 
+/**
+ * Test that Vary: Origin is appended to existing Vary headers.
+ */
+cors.route({
+  path: "/existingVaryHeader",
+  method: "GET",
+  handler: httpActionGeneric(async () => {
+    return new Response(JSON.stringify({ message: "has vary" }), {
+      headers: {
+        "Content-Type": "application/json",
+        Vary: "Accept-Encoding",
+      },
+    });
+  }),
+  allowedOrigins: ["http://localhost:3000"],
+});
+
 export default http;

--- a/packages/convex-helpers/server/cors.test.http.ts
+++ b/packages/convex-helpers/server/cors.test.http.ts
@@ -168,7 +168,7 @@ cors.route({
 });
 
 /**
- * Test that allow credentials works with *.
+ * Test that allow credentials does not work with *.
  */
 cors.route({
   path: "/allowCredentials",
@@ -185,6 +185,16 @@ cors.route({
   method: "GET",
   handler: everythingHandler,
   allowCredentials: true,
+  allowedOrigins: ["http://localhost:3000"],
+});
+
+/**
+ * Test that allow origin header is set to the specific origin.
+ */
+cors.route({
+  path: "/allowOriginWithSpecificOrigin",
+  method: "GET",
+  handler: everythingHandler,
   allowedOrigins: ["http://localhost:3000"],
 });
 

--- a/packages/convex-helpers/server/cors.test.ts
+++ b/packages/convex-helpers/server/cors.test.ts
@@ -163,6 +163,35 @@ describe("corsRouter internals", () => {
     const corsHandler = routeMap?.get("GET");
     expect(corsHandler).toBeDefined();
   });
+
+  test("throws when wildcard origin is used with allowCredentials", () => {
+    const http = new HttpRouter();
+    expect(() =>
+      corsRouter(http, {
+        allowedOrigins: ["*"],
+        allowCredentials: true,
+      }),
+    ).toThrow("Cannot use wildcard origin and allow credentials together");
+  });
+
+  test("does not throw for wildcard origin without allowCredentials", () => {
+    const http = new HttpRouter();
+    expect(() =>
+      corsRouter(http, {
+        allowedOrigins: ["*"],
+      }),
+    ).not.toThrow();
+  });
+
+  test("does not throw for specific origins with allowCredentials", () => {
+    const http = new HttpRouter();
+    expect(() =>
+      corsRouter(http, {
+        allowedOrigins: ["https://example.com"],
+        allowCredentials: true,
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe("corsRouter fetch routes", () => {

--- a/packages/convex-helpers/server/cors.test.ts
+++ b/packages/convex-helpers/server/cors.test.ts
@@ -280,6 +280,7 @@ describe("corsRouter fetch routes", () => {
     });
     expect(response.status).toBe(204);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Vary")).toBeNull();
     expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
       "GET",
     );
@@ -306,6 +307,7 @@ describe("corsRouter fetch routes", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "http://localhost:3000",
     );
+    expect(response.headers.get("Vary")).toContain("Origin");
     const body = await response.json();
     expect(body).toEqual({ message: "Custom allowed origins! Wow!" });
   });
@@ -336,6 +338,7 @@ describe("corsRouter fetch routes", () => {
     });
     expect(response.status).toBe(200);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Vary")).toBeNull();
     await verifyFactResponse(response);
   });
 
@@ -365,6 +368,7 @@ describe("corsRouter fetch routes", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "http://localhost:3000",
     );
+    expect(response.headers.get("Vary")).toContain("Origin");
     expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET");
   });
 
@@ -436,6 +440,9 @@ describe("corsRouter fetch routes", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "http://localhost:3000",
     );
+    expect(response.headers.get("Access-Control-Allow-Credentials")).toBe(
+      "true",
+    );
     const badResponse = await t.fetch("/allowCredentialsWithOrigin", {
       method: "GET",
     });
@@ -457,9 +464,9 @@ describe("corsRouter fetch routes", () => {
     );
   });
 
-  test("Route with allow credentials and specific origin", async () => {
+  test("Appends Vary: Origin to existing Vary headers", async () => {
     const t = testWithHttp();
-    const response = await t.fetch("/allowCredentialsWithOrigin", {
+    const response = await t.fetch("/existingVaryHeader", {
       method: "GET",
       headers: {
         origin: "http://localhost:3000",
@@ -469,8 +476,8 @@ describe("corsRouter fetch routes", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "http://localhost:3000",
     );
-    expect(response.headers.get("Access-Control-Allow-Credentials")).toBe(
-      "true",
-    );
+    const vary = response.headers.get("Vary");
+    expect(vary).toContain("Accept-Encoding");
+    expect(vary).toContain("Origin");
   });
 });

--- a/packages/convex-helpers/server/cors.test.ts
+++ b/packages/convex-helpers/server/cors.test.ts
@@ -170,7 +170,7 @@ describe("corsRouter fetch routes", () => {
     return {
       "access-control-allow-headers": "Content-Type",
       "access-control-allow-methods": `${method}`,
-      "access-control-allow-origin": "http://localhost:3000",
+      "access-control-allow-origin": "*",
       "access-control-max-age": "86400",
       "content-type": "application/json",
     };
@@ -279,9 +279,7 @@ describe("corsRouter fetch routes", () => {
       },
     });
     expect(response.status).toBe(204);
-    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://localhost:3000",
-    );
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
     expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
       "GET",
     );
@@ -328,7 +326,7 @@ describe("corsRouter fetch routes", () => {
     expect(body).toEqual({ message: "Dynamic allowed origins! Wow!" });
   });
 
-  test("Sets allow origin header to request origin if allowed", async () => {
+  test("Sets allow origin header to * if allowed", async () => {
     const t = testWithHttp();
     const response = await t.fetch("/fact", {
       method: "GET",
@@ -337,9 +335,7 @@ describe("corsRouter fetch routes", () => {
       },
     });
     expect(response.status).toBe(200);
-    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://localhost:3000",
-    );
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
     await verifyFactResponse(response);
   });
 
@@ -423,12 +419,9 @@ describe("corsRouter fetch routes", () => {
       },
     });
     expect(response.status).toBe(200);
-    expect(response.headers.get("Access-Control-Allow-Credentials")).toBe(
-      "true",
-    );
-    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
-      "http://localhost:3000",
-    );
+    expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    // Since we're using *, the allow origin header should be null
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
   test("Route with allowCredentials with specific origin", async () => {
@@ -448,5 +441,36 @@ describe("corsRouter fetch routes", () => {
     });
     expect(badResponse.status).toBe(200);
     expect(badResponse.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  test("Route with allow origin header set to specific origin", async () => {
+    const t = testWithHttp();
+    const response = await t.fetch("/allowOriginWithSpecificOrigin", {
+      method: "GET",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  test("Route with allow credentials and specific origin", async () => {
+    const t = testWithHttp();
+    const response = await t.fetch("/allowCredentialsWithOrigin", {
+      method: "GET",
+      headers: {
+        origin: "http://localhost:3000",
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://localhost:3000",
+    );
+    expect(response.headers.get("Access-Control-Allow-Credentials")).toBe(
+      "true",
+    );
   });
 });

--- a/packages/convex-helpers/server/cors.ts
+++ b/packages/convex-helpers/server/cors.ts
@@ -286,12 +286,8 @@ const handleCors = ({
   /**
    * Build up the set of CORS headers
    */
-  const commonHeaders: Record<string, string> = {
-    Vary: "Origin",
-  };
-  if (allowCredentials) {
-    commonHeaders["Access-Control-Allow-Credentials"] = "true";
-  }
+  const commonHeaders: Record<string, string> = {};
+
   if (exposedHeaders.length > 0) {
     commonHeaders["Access-Control-Expose-Headers"] = exposedHeaders.join(", ");
   }
@@ -306,7 +302,11 @@ const handleCors = ({
   async function isAllowedOrigin(request: Request): Promise<boolean> {
     const requestOrigin = request.headers.get("origin");
     if (!requestOrigin) return false;
-    return (await parseAllowedOrigins(request)).some((allowed) => {
+
+    const allowedOrigins = await parseAllowedOrigins(request);
+    if (allowedOrigins.includes("*") && allowCredentials) return false;
+
+    return allowedOrigins.some((allowed) => {
       if (allowed === "*") return true;
       if (allowed === requestOrigin) return true;
       if (allowed.startsWith("*.")) {
@@ -355,7 +355,7 @@ const handleCors = ({
         requestOrigin &&
         !allowCredentials
       ) {
-        allowOrigins = requestOrigin;
+        allowOrigins = "*";
       } else if (requestOrigin) {
         // Check if the request origin matches any of the allowed origins
         // (including wildcard subdomain matching if configured)
@@ -377,6 +377,10 @@ const handleCors = ({
       if (request.method === "OPTIONS") {
         const responseHeaders = new Headers({
           ...commonHeaders,
+          ...(allowOrigins === "*" ? {} : { Vary: "Origin" }),
+          ...(allowOrigins !== null && allowCredentials
+            ? { "Access-Control-Allow-Credentials": "true" }
+            : {}),
           ...(allowOrigins
             ? { "Access-Control-Allow-Origin": allowOrigins }
             : {}),
@@ -426,6 +430,14 @@ const handleCors = ({
       Object.entries(commonHeaders).forEach(([key, value]) => {
         newHeaders.set(key, value);
       });
+
+      if (allowOrigins !== "*") {
+        newHeaders.append("Vary", "Origin");
+      }
+
+      if (allowOrigins !== null && allowCredentials) {
+        newHeaders.set("Access-Control-Allow-Credentials", "true");
+      }
 
       if (debug) {
         console.log("CORS response headers", newHeaders);

--- a/packages/convex-helpers/server/cors.ts
+++ b/packages/convex-helpers/server/cors.ts
@@ -298,15 +298,17 @@ const handleCors = ({
       : await allowedOrigins(request);
   }
 
-  // Helper function to check if origin is allowed (including wildcard subdomain matching)
-  async function isAllowedOrigin(request: Request): Promise<boolean> {
-    const requestOrigin = request.headers.get("origin");
-    if (!requestOrigin) return false;
+  /**
+   * Check if a request origin is allowed given already-parsed allowed origins.
+   * Includes wildcard subdomain matching (e.g. "*.example.com").
+   */
+  function isAllowedOrigin(
+    requestOrigin: string,
+    parsedOrigins: string[],
+  ): boolean {
+    if (parsedOrigins.includes("*") && allowCredentials) return false;
 
-    const allowedOrigins = await parseAllowedOrigins(request);
-    if (allowedOrigins.includes("*") && allowCredentials) return false;
-
-    return allowedOrigins.some((allowed) => {
+    return parsedOrigins.some((allowed) => {
       if (allowed === "*") return true;
       if (allowed === requestOrigin) return true;
       if (allowed.startsWith("*.")) {
@@ -359,7 +361,7 @@ const handleCors = ({
       } else if (requestOrigin) {
         // Check if the request origin matches any of the allowed origins
         // (including wildcard subdomain matching if configured)
-        if (await isAllowedOrigin(request)) {
+        if (isAllowedOrigin(requestOrigin, parsedAllowedOrigins)) {
           allowOrigins = requestOrigin;
         }
       }

--- a/packages/convex-helpers/server/cors.ts
+++ b/packages/convex-helpers/server/cors.ts
@@ -102,6 +102,19 @@ export const corsRouter = (
 ): CorsHttpRouter => {
   const allowedExactMethodsByPath: Map<string, Set<string>> = new Map();
   const allowedPrefixMethodsByPath: Map<string, Set<string>> = new Map();
+
+  // Eagerly throw on invalid configuration
+  if (
+    corsConfig &&
+    Array.isArray(corsConfig.allowedOrigins) &&
+    corsConfig.allowedOrigins.includes("*") &&
+    corsConfig.allowCredentials
+  ) {
+    throw new Error(
+      "Cannot use wildcard origin and allow credentials together",
+    );
+  }
+
   return {
     http,
     route: (routeSpec: RouteSpecWithCors): void => {


### PR DESCRIPTION
- append Vary header instead of setting, respect user headers
- no Vary header change when allowed origin is *
- allow all origins + allow credentials is a cors no-op, neither header goes back in that case
- send literal * for allow all origins instead of reflecting request origin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CORS header behavior: wildcard origins no longer allow credentials; Access-Control-Allow-Origin, Access-Control-Allow-Credentials and Vary headers are now set conditionally per response to follow CORS rules.

* **Tests**
  * Expanded CORS test coverage with new scenarios and test routes validating origin-specific responses, preflight handling, and appending Origin to existing Vary headers.

* **Documentation**
  * Clarified inline docs around allow-credentials and wildcard origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->