### PR TITLE
Fix open-api-spec crash on nullable fields with empty schema

### DIFF
--- a/packages/convex-helpers/cli/openApiSpec.test.ts
+++ b/packages/convex-helpers/cli/openApiSpec.test.ts
@@ -29,3 +29,43 @@ test("generateValidSpec", async () => {
 
   expect(JSON.parse(output.toString())["totals"]).toHaveProperty("errors", 0);
 }, 10000);
+
+// Regression test: nullable fields with "any" type (empty schema {}) should produce valid YAML.
+test("nullable any field generates valid spec", async () => {
+  const functionsJson = JSON.stringify({
+    url: "https://test-convex-url.convex.cloud",
+    functions: [
+      {
+        args: {
+          type: "object",
+          value: {
+            claimedAt: {
+              fieldType: {
+                type: "union",
+                value: [{ type: "any" }, { type: "null" }],
+              },
+              optional: false,
+            },
+          },
+        },
+        functionType: "Query",
+        identifier: "example.js:get",
+        returns: { type: "any" },
+        visibility: { kind: "public" },
+      },
+    ],
+  });
+
+  const apiSpec = generateOpenApiSpec(JSON.parse(functionsJson), true);
+
+  const testFileName = "openApiSpec.nullable-any.test.yaml";
+  fs.writeFileSync(testFileName, apiSpec, "utf-8");
+
+  const output = execSync(`npx redocly lint ${testFileName} --format='json'`);
+
+  fs.unlinkSync(testFileName);
+
+  expect(JSON.parse(output.toString())["totals"]).toHaveProperty("errors", 0);
+  // nullable any should produce {} (any schema already permits null)
+  expect(apiSpec).toMatch(/claimedAt:\s*\n\s*\{\}/);
+}, 10000);

--- a/packages/convex-helpers/cli/openApiSpec.ts
+++ b/packages/convex-helpers/cli/openApiSpec.ts
@@ -124,9 +124,11 @@ function generateSchemaFromValidator(validatorJson: ValidatorJSON): string {
         (v) => v.type !== "null",
       );
       if (nonNullMembers.length === 1 && nullMember !== undefined) {
-        return `${generateSchemaFromValidator(
-          nonNullMembers[0]!,
-        )}\nnullable: true`;
+        const innerSchema = generateSchemaFromValidator(nonNullMembers[0]!);
+        if (innerSchema === "{}") {
+          return "{}";
+        }
+        return `${innerSchema}\nnullable: true`;
       }
       const members: string[] = nonNullMembers.map((v) =>
         generateSchemaFromValidator(v),


### PR DESCRIPTION
When a nullable union contained an "any" type, generateSchemaFromValidator
produced "{}\nnullable: true" which is invalid YAML. Since an empty schema
({}) already permits any value including null in OpenAPI 3.0, we now return
"{}" unchanged instead of appending nullable: true.

Fixes #957