### PR TITLE
Update TypeScript to v6, add `"types": ["node"]`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "npm-run-all2": "8.0.4",
         "pkg-pr-new": "0.0.66",
         "prettier": "3.8.1",
-        "typescript": "5.9.3",
+        "typescript": "6.0.2",
         "typescript-eslint": "8.58.1",
         "vitest": "4.1.3",
         "yaml": "2.8.3",
@@ -10082,9 +10082,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "npm-run-all2": "8.0.4",
     "pkg-pr-new": "0.0.66",
     "prettier": "3.8.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.2",
     "typescript-eslint": "8.58.1",
     "vitest": "4.1.3",
     "yaml": "2.8.3",

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -167,7 +167,7 @@
     "convex": "^1.32.0",
     "hono": "^4.0.5",
     "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-    "typescript": "^5.5",
+    "typescript": "^5.5 || ^6.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/convex-helpers/tsconfig.json
+++ b/packages/convex-helpers/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
This starts with #946, merges `main`, then adds `"types": ["node"]` to `packages/convex-helpers/tsconfig.json` in response to the TypeScript 6 breaking change, as explained in https://github.com/get-convex/convex-helpers/pull/946#issuecomment-4276737051.

I'm a TypeScript novice who made this change entirely by hand; hopefully this will work.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated TypeScript development tooling to version 6.0.2.
* Expanded TypeScript version compatibility to support both 5.5+ and 6.0.0+.
* Enhanced type definitions configuration for improved development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->