### PR TITLE
chore(deps): update dependency typescript to v6

### DIFF
--- a/convex/counter.ts
+++ b/convex/counter.ts
@@ -10,7 +10,7 @@ export const getCounter = query({
   handler: async (ctx, { counterName }) => {
     const counterDoc = await ctx.db
       .query("counter_table")
-      .filter((q) => q.eq(q.field("name"), counterName))
+      .withIndex("name", (q) => q.eq("name", counterName))
       .first();
     return counterDoc === null ? 0 : counterDoc.counter;
   },
@@ -37,7 +37,7 @@ export const getCounterOrThrow = query({
   handler: async (ctx, { counterName }): Promise<number> => {
     const counterDoc = await ctx.db
       .query("counter_table")
-      .filter((q) => q.eq(q.field("name"), counterName))
+      .withIndex("name", (q) => q.eq("name", counterName))
       .first();
     if (counterDoc === null) {
       throw new Error("Counter not found");
@@ -63,7 +63,7 @@ export const incrementCounter = mutation({
   ) => {
     const counterDoc = await ctx.db
       .query("counter_table")
-      .filter((q) => q.eq(q.field("name"), counterName))
+      .withIndex("name", (q) => q.eq("name", counterName))
       .first();
     if (counterDoc === null) {
       await ctx.db.insert("counter_table", {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -28,7 +28,10 @@ export default defineSchema({
     .index("room_updated", ["room", "updated"])
     // Index for updating presence data
     .index("user_room", ["user", "room"]),
-  counter_table: defineTable({ name: v.string(), counter: v.number() }),
+  counter_table: defineTable({ name: v.string(), counter: v.number() }).index(
+    "name",
+    ["name"],
+  ),
   sum_table: defineTable({ sum: v.number() }),
   notes: defineTable({ session: v.string(), note: v.string() }),
   migrations: migrationsTable,

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -21,5 +21,5 @@
     "noEmit": true
   },
   "include": ["./**/*"],
-  "exclude": ["./_generated"]
+  "exclude": ["./_generated", "**/*.test.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "npm-run-all2": "8.0.4",
         "pkg-pr-new": "0.0.66",
         "prettier": "3.8.1",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.58.1",
         "vitest": "4.1.3",
         "yaml": "2.8.3",
@@ -10082,9 +10082,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "npm-run-all2": "8.0.4",
     "pkg-pr-new": "0.0.66",
     "prettier": "3.8.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.58.1",
     "vitest": "4.1.3",
     "yaml": "2.8.3",

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -167,7 +167,7 @@
     "convex": "^1.32.0",
     "hono": "^4.0.5",
     "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-    "typescript": "^5.5",
+    "typescript": "^5.5 || ^6.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/convex-helpers/react/sessions.ts
+++ b/packages/convex-helpers/react/sessions.ts
@@ -27,7 +27,6 @@ import type {
   FunctionArgs,
   FunctionReference,
   FunctionReturnType,
-  OptionalRestArgs,
   PaginationOptions,
   PaginationResult,
 } from "convex/server";

--- a/packages/convex-helpers/server/filter.test.ts
+++ b/packages/convex-helpers/server/filter.test.ts
@@ -38,6 +38,7 @@ test("filter", async () => {
   const evensBuiltin = await t.run((ctx) =>
     ctx.db
       .query("tableA")
+      // eslint-disable-next-line @convex-dev/no-filter-in-query
       .filter((q) => q.eq(q.mod(q.field("count"), 2), 0))
       .collect(),
   );

--- a/packages/convex-helpers/server/filter.ts
+++ b/packages/convex-helpers/server/filter.ts
@@ -48,6 +48,7 @@ class QueryWithFilter<
     this.p = p;
   }
   filter(predicate: (q: FilterBuilder<T>) => Expression<boolean>): this {
+    // eslint-disable-next-line @convex-dev/no-filter-in-query
     return new QueryWithFilter(this.q.filter(predicate), this.p) as this;
   }
   order(order: "asc" | "desc"): QueryWithFilter<T> {

--- a/packages/convex-helpers/tsconfig.json
+++ b/packages/convex-helpers/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/packages/convex-helpers/tsconfig.json
+++ b/packages/convex-helpers/tsconfig.json
@@ -32,7 +32,9 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": ["node"] /* Specify type package names to be included without being referenced in a source file. */,
+    "types": [
+      "node"
+    ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["node", "vitest/globals"],
+    "types": ["node", "vitest/globals"]
   },
   "include": ["./src", "./convex", "./packages/convex-helpers/**/*.test.ts"],
-  "exclude": ["**/dist/**"],
+  "exclude": ["**/dist/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
@@ -13,7 +12,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["node", "vitest/globals"],
   },
-  "include": ["./src", "./convex", "./packages/convex-helpers/**/*.test.ts"]
+  "include": ["./src", "./convex", "./packages/convex-helpers/**/*.test.ts"],
+  "exclude": ["**/dist/**"],
 }


### PR DESCRIPTION
Closes #946 

chore(deps): update dependency typescript to v6

call out node types explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript dev dependency to 6.0.3 and broadened peer support to include 6.x.
  * Adjusted TypeScript configs to improve type resolution and exclude build artifacts and tests from type-checking.
* **Bug Fixes**
  * Counter lookups now use an index and the counter table gains a name index for more reliable/faster retrieval.
* **Tests**
  * Added targeted lint suppression in a test to allow an existing query pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->