### PR TITLE
Streams: make page split recommendations less aggressive

### DIFF
--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -367,6 +367,88 @@ describe("stream", () => {
     });
   });
 
+  test("sparse filterWith does not produce SplitRecommended", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      // Insert 20 documents where only every 5th one matches the filter.
+      // Requesting numItems: 3 means softMaxRowsToRead = 4, but we'll scan
+      // ~15 rows to find 3 matches — a ratio of 5:1. Without the fix this
+      // triggers SplitRecommended on every page, causing exponential splits.
+      for (let i = 1; i <= 20; i++) {
+        await ctx.db.insert("foo", { a: 1, b: i, c: i % 5 === 0 ? 1 : 0 });
+      }
+      const filteredQuery = stream(ctx.db, schema)
+        .query("foo")
+        .withIndex("abc", (q) => q.eq("a", 1))
+        .filterWith(async (doc) => doc.c === 1);
+
+      const page1 = await filteredQuery.paginate({
+        numItems: 3,
+        cursor: null,
+      });
+      expect(page1.page).toHaveLength(3);
+      expect(page1.page.map(stripSystemFields)).toEqual([
+        { a: 1, b: 5, c: 1 },
+        { a: 1, b: 10, c: 1 },
+        { a: 1, b: 15, c: 1 },
+      ]);
+      // The key assertion: sparse filterWith should NOT recommend splitting.
+      // The scan-to-match ratio is 5:1, well above the 2x threshold.
+      expect(page1.pageStatus).toBeUndefined();
+    });
+  });
+
+  test("mildly sparse filterWith still produces SplitRecommended", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      // 6 docs, every other one matches. With numItems: 2, softMaxRowsToRead = 3.
+      // We scan 4 rows to find 2 matches → ratio = 4/2 = 2.0, at the threshold.
+      await ctx.db.insert("foo", { a: 2, b: 1, c: 0 }); // filtered out
+      await ctx.db.insert("foo", { a: 2, b: 2, c: 1 }); // match 1
+      await ctx.db.insert("foo", { a: 2, b: 3, c: 0 }); // filtered out
+      await ctx.db.insert("foo", { a: 2, b: 4, c: 1 }); // match 2 → break
+      await ctx.db.insert("foo", { a: 2, b: 5, c: 0 });
+      await ctx.db.insert("foo", { a: 2, b: 6, c: 1 });
+
+      const filteredQuery = stream(ctx.db, schema)
+        .query("foo")
+        .withIndex("abc", (q) => q.eq("a", 2))
+        .filterWith(async (doc) => doc.c === 1);
+
+      const page1 = await filteredQuery.paginate({
+        numItems: 2,
+        cursor: null,
+      });
+      expect(page1.page).toHaveLength(2);
+      // Scanned 4 rows, got 2 matches → ratio = 2.0, at the threshold.
+      expect(page1.pageStatus).toBe("SplitRecommended");
+    });
+  });
+
+  test("SplitRequired still fires with filterWith when maximumRowsRead is hit", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      for (let i = 1; i <= 20; i++) {
+        await ctx.db.insert("foo", { a: 3, b: i, c: i % 5 === 0 ? 1 : 0 });
+      }
+      const filteredQuery = stream(ctx.db, schema)
+        .query("foo")
+        .withIndex("abc", (q) => q.eq("a", 3))
+        .filterWith(async (doc) => doc.c === 1);
+
+      const page1 = await filteredQuery.paginate({
+        numItems: 3,
+        cursor: null,
+        maximumRowsRead: 8,
+      });
+      // Hit the hard row limit before finding 3 matches.
+      // Only 1 match in first 8 rows (b=5).
+      expect(page1.page).toHaveLength(1);
+      expect(page1.pageStatus).toBe("SplitRequired");
+      expect(page1.splitCursor).toBeDefined();
+    });
+  });
+
   test("merge orderBy streams", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -367,65 +367,78 @@ describe("stream", () => {
     });
   });
 
-  test("sparse filterWith does not produce SplitRecommended", async () => {
+  test("no SplitRecommended without endCursor", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      // Insert 20 documents where only every 5th one matches the filter.
-      // Requesting numItems: 3 means softMaxRowsToRead = 4, but we'll scan
-      // ~15 rows to find 3 matches — a ratio of 5:1. Without the fix this
-      // triggers SplitRecommended on every page, causing exponential splits.
       for (let i = 1; i <= 20; i++) {
-        await ctx.db.insert("foo", { a: 1, b: i, c: i % 5 === 0 ? 1 : 0 });
+        await ctx.db.insert("foo", { a: 1, b: i, c: i % 2 === 0 ? 1 : 0 });
       }
-      const filteredQuery = stream(ctx.db, schema)
+      const query = stream(ctx.db, schema)
         .query("foo")
         .withIndex("abc", (q) => q.eq("a", 1))
         .filterWith(async (doc) => doc.c === 1);
 
-      const page1 = await filteredQuery.paginate({
+      const page1 = await query.paginate({
         numItems: 3,
         cursor: null,
       });
       expect(page1.page).toHaveLength(3);
-      expect(page1.page.map(stripSystemFields)).toEqual([
-        { a: 1, b: 5, c: 1 },
-        { a: 1, b: 10, c: 1 },
-        { a: 1, b: 15, c: 1 },
-      ]);
-      // The key assertion: sparse filterWith should NOT recommend splitting.
-      // The scan-to-match ratio is 5:1, well above the 2x threshold.
       expect(page1.pageStatus).toBeUndefined();
     });
   });
 
-  test("mildly sparse filterWith still produces SplitRecommended", async () => {
+  test("SplitRecommended when endCursor set and page exceeds 2x numItems", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      // 6 docs, every other one matches. With numItems: 2, softMaxRowsToRead = 3.
-      // We scan 4 rows to find 2 matches → ratio = 4/2 = 2.0, at the threshold.
-      await ctx.db.insert("foo", { a: 2, b: 1, c: 0 }); // filtered out
-      await ctx.db.insert("foo", { a: 2, b: 2, c: 1 }); // match 1
-      await ctx.db.insert("foo", { a: 2, b: 3, c: 0 }); // filtered out
-      await ctx.db.insert("foo", { a: 2, b: 4, c: 1 }); // match 2 → break
-      await ctx.db.insert("foo", { a: 2, b: 5, c: 0 });
-      await ctx.db.insert("foo", { a: 2, b: 6, c: 1 });
-
-      const filteredQuery = stream(ctx.db, schema)
+      for (let i = 1; i <= 20; i++) {
+        await ctx.db.insert("foo", { a: 1, b: i, c: i % 2 === 0 ? 1 : 0 });
+      }
+      const query = stream(ctx.db, schema)
         .query("foo")
-        .withIndex("abc", (q) => q.eq("a", 2))
+        .withIndex("abc", (q) => q.eq("a", 1))
         .filterWith(async (doc) => doc.c === 1);
 
-      const page1 = await filteredQuery.paginate({
-        numItems: 2,
+      const endCursor = JSON.stringify(convexToJson([1, 100, 0]));
+      const page = await query.paginate({
+        numItems: 3,
         cursor: null,
+        endCursor,
       });
-      expect(page1.page).toHaveLength(2);
-      // Scanned 4 rows, got 2 matches → ratio = 2.0, at the threshold.
-      expect(page1.pageStatus).toBe("SplitRecommended");
+      // 10 matches out of 20 docs. 10 >= numItems * 2 (6) → SplitRecommended.
+      expect(page.page).toHaveLength(10);
+      expect(page.pageStatus).toBe("SplitRecommended");
+      expect(page.splitCursor).toBeDefined();
     });
   });
 
-  test("SplitRequired still fires with filterWith when maximumRowsRead is hit", async () => {
+  test("SplitRecommended when scan approaches transaction limit", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      // SOFT_MAX_PAGE_LEN = 8192 * 3/4 = 6144. Insert that many docs where
+      // only a handful match the filter, so indexKeys hits the soft max while
+      // page.length stays well below numItems * 2.
+      for (let i = 1; i <= 6144; i++) {
+        await ctx.db.insert("foo", { a: 4, b: i, c: i % 1000 === 0 ? 1 : 0 });
+      }
+      const query = stream(ctx.db, schema)
+        .query("foo")
+        .withIndex("abc", (q) => q.eq("a", 4))
+        .filterWith(async (doc) => doc.c === 1);
+
+      const endCursor = JSON.stringify(convexToJson([4, 10000, 0]));
+      const page = await query.paginate({
+        numItems: 5,
+        cursor: null,
+        endCursor,
+      });
+      // 6 matches (i=1000,2000,...,6000), but 6144 index keys scanned.
+      expect(page.page).toHaveLength(6);
+      expect(page.pageStatus).toBe("SplitRecommended");
+      expect(page.splitCursor).toBeDefined();
+    });
+  });
+
+  test("SplitRequired fires with filterWith when maximumRowsRead is hit", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       for (let i = 1; i <= 20; i++) {

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -411,6 +411,32 @@ describe("stream", () => {
     });
   });
 
+  test("SplitRecommended when scan approaches scan limit regardless of endCursor", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      // SOFT_MAX_SCAN_LEN = 32000 * 3/4 = 24000. Insert that many docs where
+      // only a handful match the filter, so indexKeys hits the soft max while
+      // page.length stays below numItems + 1.
+      for (let i = 1; i <= 24000; i++) {
+        await ctx.db.insert("foo", { a: 4, b: i, c: i % 3000 === 0 ? 1 : 0 });
+      }
+      const query = stream(ctx.db, schema)
+        .query("foo")
+        .withIndex("abc", (q) => q.eq("a", 4))
+        .filterWith(async (doc) => doc.c === 1);
+
+      const page = await query.paginate({
+        numItems: 10,
+        cursor: null,
+        endCursor: null,
+      });
+      // a few matches, but many index keys scanned.
+      expect(page.page).toHaveLength(8);
+      expect(page.pageStatus).toBe("SplitRecommended");
+      expect(page.splitCursor).toBeDefined();
+    });
+  });
+
   test("SplitRequired fires with filterWith when maximumRowsRead is hit", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -414,10 +414,10 @@ describe("stream", () => {
   test("SplitRecommended when scan approaches scan limit regardless of endCursor", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      // SOFT_MAX_SCAN_LEN = 32000 * 3/4 = 24000. Insert that many docs where
+      // SOFT_MAX_SCAN_LEN = 32000 / 2 = 16000. Insert that many docs where
       // only a handful match the filter, so indexKeys hits the soft max while
       // page.length stays below numItems + 1.
-      for (let i = 1; i <= 24000; i++) {
+      for (let i = 1; i <= 16000; i++) {
         await ctx.db.insert("foo", { a: 4, b: i, c: i % 3000 === 0 ? 1 : 0 });
       }
       const query = stream(ctx.db, schema)
@@ -431,7 +431,7 @@ describe("stream", () => {
         endCursor: null,
       });
       // a few matches, but many index keys scanned.
-      expect(page.page).toHaveLength(8);
+      expect(page.page).toHaveLength(5);
       expect(page.pageStatus).toBe("SplitRecommended");
       expect(page.splitCursor).toBeDefined();
     });

--- a/packages/convex-helpers/server/stream.test.ts
+++ b/packages/convex-helpers/server/stream.test.ts
@@ -387,10 +387,10 @@ describe("stream", () => {
     });
   });
 
-  test("SplitRecommended when endCursor set and page exceeds 2x numItems", async () => {
+  test("SplitRecommended when endCursor set and page exceeds numItems + 1", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      for (let i = 1; i <= 20; i++) {
+      for (let i = 1; i <= 10; i++) {
         await ctx.db.insert("foo", { a: 1, b: i, c: i % 2 === 0 ? 1 : 0 });
       }
       const query = stream(ctx.db, schema)
@@ -404,35 +404,8 @@ describe("stream", () => {
         cursor: null,
         endCursor,
       });
-      // 10 matches out of 20 docs. 10 >= numItems * 2 (6) → SplitRecommended.
-      expect(page.page).toHaveLength(10);
-      expect(page.pageStatus).toBe("SplitRecommended");
-      expect(page.splitCursor).toBeDefined();
-    });
-  });
-
-  test("SplitRecommended when scan approaches transaction limit", async () => {
-    const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
-      // SOFT_MAX_PAGE_LEN = 8192 * 3/4 = 6144. Insert that many docs where
-      // only a handful match the filter, so indexKeys hits the soft max while
-      // page.length stays well below numItems * 2.
-      for (let i = 1; i <= 6144; i++) {
-        await ctx.db.insert("foo", { a: 4, b: i, c: i % 1000 === 0 ? 1 : 0 });
-      }
-      const query = stream(ctx.db, schema)
-        .query("foo")
-        .withIndex("abc", (q) => q.eq("a", 4))
-        .filterWith(async (doc) => doc.c === 1);
-
-      const endCursor = JSON.stringify(convexToJson([4, 10000, 0]));
-      const page = await query.paginate({
-        numItems: 5,
-        cursor: null,
-        endCursor,
-      });
-      // 6 matches (i=1000,2000,...,6000), but 6144 index keys scanned.
-      expect(page.page).toHaveLength(6);
+      // 5 matches out of 10 docs. 5 >= numItems + 1 (4) → SplitRecommended.
+      expect(page.page).toHaveLength(5);
       expect(page.pageStatus).toBe("SplitRecommended");
       expect(page.splitCursor).toBeDefined();
     });

--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -428,8 +428,15 @@ export abstract class QueryStream<
       pageStatus = "SplitRequired";
       splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
     } else if (indexKeys.length >= softMaxRowsToRead) {
-      pageStatus = "SplitRecommended";
-      splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
+      // When the scan-to-match ratio is high (sparse filter), splitting the
+      // range won't improve density — it just doubles subscriptions and can
+      // cause exponential split cascades on the client.
+      const scanRatio =
+        page.length > 0 ? indexKeys.length / page.length : Infinity;
+      if (scanRatio <= 2) {
+        pageStatus = "SplitRecommended";
+        splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
+      }
     }
     return {
       page,

--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -30,9 +30,13 @@ import type {
 export type IndexKey = (Value | undefined)[];
 
 // From https://docs.convex.dev/production/state/limits#transactions
-const MAX_DOCUMENTS_TO_SCAN = 32000;
-// Value used to trigger page split suggestions (nearing the max).
-const SOFT_MAX_SCAN_LEN = (MAX_DOCUMENTS_TO_SCAN * 3) / 4;
+const MAX_DOCUMENT_SCAN_LEN = 32000;
+// Value used to trigger page split suggestions. This is kind of
+// a backstop value to mitigate additional scans over the full
+// original range if documents change later. Making it smaller
+// would result in more splits (equal to the divisor) as the
+// number of documents scanned approaches the max.
+const SOFT_MAX_SCAN_LEN = MAX_DOCUMENT_SCAN_LEN / 2;
 
 //
 // Helper functions

--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -29,6 +29,11 @@ import type {
 
 export type IndexKey = (Value | undefined)[];
 
+// From https://docs.convex.dev/production/state/limits#transactions
+const MAX_DOCUMENTS_TO_SCAN = 32000;
+// Value used to trigger page split suggestions (nearing the max).
+const SOFT_MAX_SCAN_LEN = (MAX_DOCUMENTS_TO_SCAN * 3) / 4;
+
 //
 // Helper functions
 //
@@ -426,7 +431,10 @@ export abstract class QueryStream<
     if (hitLimit) {
       pageStatus = "SplitRequired";
       splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
-    } else if (page.length > opts.numItems + 1) {
+    } else if (
+      indexKeys.length >= SOFT_MAX_SCAN_LEN ||
+      page.length > opts.numItems + 1
+    ) {
       pageStatus = "SplitRecommended";
       splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
     }

--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -29,6 +29,11 @@ import type {
 
 export type IndexKey = (Value | undefined)[];
 
+// From https://docs.convex.dev/production/state/limits#documents
+const MAX_ARRAY_LEN = 8192;
+// Value used to trigger page split suggestions (nearing the max).
+const SOFT_MAX_PAGE_LEN = (MAX_ARRAY_LEN * 3) / 4;
+
 //
 // Helper functions
 //
@@ -374,7 +379,6 @@ export abstract class QueryStream<
       inclusive: true,
     };
     const maxRowsToRead = opts.maximumRowsRead;
-    const softMaxRowsToRead = opts.numItems + 1;
     let maxRows: number | undefined = opts.numItems;
     if (opts.endCursor) {
       newEndKey = {
@@ -427,16 +431,16 @@ export abstract class QueryStream<
     if (hitLimit) {
       pageStatus = "SplitRequired";
       splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
-    } else if (indexKeys.length >= softMaxRowsToRead) {
-      // When the scan-to-match ratio is high (sparse filter), splitting the
-      // range won't improve density — it just doubles subscriptions and can
-      // cause exponential split cascades on the client.
-      const scanRatio =
-        page.length > 0 ? indexKeys.length / page.length : Infinity;
-      if (scanRatio <= 2) {
-        pageStatus = "SplitRecommended";
-        splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
-      }
+    } else if (
+      (indexKeys.length >= SOFT_MAX_PAGE_LEN ||
+        page.length >= opts.numItems * 2) &&
+      opts.endCursor
+    ) {
+      // Recommend a split when an end cursor is set and either of the following is true of the page:
+      // 1. It is approaching transaction limits (the "soft max" check).
+      // 2. It contains at least twice the number of documents that the client initially requested.
+      pageStatus = "SplitRecommended";
+      splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
     }
     return {
       page,

--- a/packages/convex-helpers/server/stream.ts
+++ b/packages/convex-helpers/server/stream.ts
@@ -29,11 +29,6 @@ import type {
 
 export type IndexKey = (Value | undefined)[];
 
-// From https://docs.convex.dev/production/state/limits#documents
-const MAX_ARRAY_LEN = 8192;
-// Value used to trigger page split suggestions (nearing the max).
-const SOFT_MAX_PAGE_LEN = (MAX_ARRAY_LEN * 3) / 4;
-
 //
 // Helper functions
 //
@@ -431,14 +426,7 @@ export abstract class QueryStream<
     if (hitLimit) {
       pageStatus = "SplitRequired";
       splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
-    } else if (
-      (indexKeys.length >= SOFT_MAX_PAGE_LEN ||
-        page.length >= opts.numItems * 2) &&
-      opts.endCursor
-    ) {
-      // Recommend a split when an end cursor is set and either of the following is true of the page:
-      // 1. It is approaching transaction limits (the "soft max" check).
-      // 2. It contains at least twice the number of documents that the client initially requested.
+    } else if (page.length > opts.numItems + 1) {
       pageStatus = "SplitRecommended";
       splitCursor = indexKeys[Math.floor((indexKeys.length - 1) / 2)];
     }


### PR DESCRIPTION
Previously a split was recommended when the number of scanned documents was 1 greater than the number of requested documents. For queries where many documents had to be scanned to satisfy the requested number of documents, this would lead to cascading page splits.

Now split recommendations based on number of documents scanned use a threshold based on the published limits. A split recommendation will also happen if the returned page size is somewhat more than the requested page size, which can only happen with an end cursor set.

If there is no end cursor, the page results are naturally truncated by the requested number of items (that's existing behavior).

This addresses https://github.com/get-convex/convex-backend/issues/443.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

