### PR TITLE
Fix zod4 ConvexError test expectations

### DIFF
--- a/packages/convex-helpers/server/zod4.functions.test.ts
+++ b/packages/convex-helpers/server/zod4.functions.test.ts
@@ -456,9 +456,15 @@ describe("zCustomQuery, zCustomMutation, zCustomAction", () => {
         } as any),
       ).rejects.toThrowError(
         expect.objectContaining({
-          data: expect.stringMatching(
-            /(?=.*"ZodError")(?=.*"name")(?=.*"invalid_type")(?=.*"expected")(?=.*"string")/s,
-          ),
+          data: {
+            ZodError: expect.arrayContaining([
+              expect.objectContaining({
+                code: "invalid_type",
+                expected: "string",
+                path: ["name"],
+              }),
+            ]),
+          },
         }),
       );
     });
@@ -545,9 +551,15 @@ describe("zCustomQuery, zCustomMutation, zCustomAction", () => {
         }),
       ).rejects.toThrowError(
         expect.objectContaining({
-          data: expect.stringMatching(
-            /(?=.*"ZodError")(?=.*"encodedNumber")(?=.*"invalid_type")(?=.*"expected")(?=.*"number")/s,
-          ),
+          data: {
+            ZodError: expect.arrayContaining([
+              expect.objectContaining({
+                code: "invalid_type",
+                expected: "number",
+                path: ["encodedNumber"],
+              }),
+            ]),
+          },
         }),
       );
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Describe your PR here. -->

Updates the zod4 function tests to assert the structured `ConvexError.data.ZodError` payload returned by current Convex versions instead of expecting a serialized string.

Verification:
- `npm test -- packages/convex-helpers/server/zod4.functions.test.ts`
- `npm run format`
- `npm test`

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dce20a7c-f091-4ecf-860b-9fa330a107ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dce20a7c-f091-4ecf-860b-9fa330a107ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

