### PR TITLE
Add `Variables` type parameter to `HonoWithConvex` and `HttpRouterWithHono`

### DIFF
--- a/packages/convex-helpers/CHANGELOG.md
+++ b/packages/convex-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## next
+
+- `HonoWithConvex` and `HttpRouterWithHono` now accept an optional `Variables`
+  type parameter, so consumers using middleware-driven typed context state
+  (`c.var` / `c.set` / `c.get`) no longer need to cast their `Hono` app.
+
 ## 0.1.115
 
 - Supports typescript ^6.0.0

--- a/packages/convex-helpers/server/hono.ts
+++ b/packages/convex-helpers/server/hono.ts
@@ -45,11 +45,19 @@ declare global {
 /**
  * A type representing a Hono app with `c.env` containing Convex's
  * `HttpEndpointCtx` (e.g. `c.env.runQuery` is valid).
+ *
+ * Optionally accepts a `Variables` type parameter so consumers can use
+ * middleware-driven typed context state (`c.var` / `c.set` / `c.get`) without
+ * casting when passing the app to `HttpRouterWithHono`.
  */
-export type HonoWithConvex<ActionCtx extends GenericActionCtx<any>> = Hono<{
+export type HonoWithConvex<
+  ActionCtx extends GenericActionCtx<any>,
+  Variables extends Record<string, unknown> = Record<string, never>,
+> = Hono<{
   Bindings: {
     [Name in keyof ActionCtx]: ActionCtx[Name];
   };
+  Variables: Variables;
 }>;
 
 /**
@@ -78,12 +86,13 @@ export type HonoWithConvex<ActionCtx extends GenericActionCtx<any>> = Hono<{
  */
 export class HttpRouterWithHono<
   ActionCtx extends GenericActionCtx<any>,
+  Variables extends Record<string, unknown> = Record<string, never>,
 > extends HttpRouter {
-  private _app: HonoWithConvex<ActionCtx>;
+  private _app: HonoWithConvex<ActionCtx, Variables>;
   private _handler: PublicHttpAction;
   private _handlerInfoCache: Map<any, { method: RoutableMethod; path: string }>;
 
-  constructor(app: HonoWithConvex<ActionCtx>) {
+  constructor(app: HonoWithConvex<ActionCtx, Variables>) {
     super();
     this._app = app;
     // Single Convex httpEndpoint handler that just forwards the request to the


### PR DESCRIPTION
Fixes #963

Add optional `Variables` type parameter to `HonoWithConvex` and `HttpRouterWithHono`

Both `HonoWithConvex` and `HttpRouterWithHono` now accept an optional `Variables` generic parameter (defaulting to `Record<string, never>`), which is passed through to Hono's `Variables` env slot. This allows consumers who use middleware to set typed context state via `c.var`, `c.set`, and `c.get` to pass their app directly to `HttpRouterWithHono` without needing a cast.