### PR TITLE
Add lazy split strategy for usePaginatedQuery

### DIFF
--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -43,6 +43,10 @@
       "types": "./react/sessions.d.ts",
       "default": "./react/sessions.js"
     },
+    "./react/splitStrategy": {
+      "types": "./react/splitStrategy.d.ts",
+      "default": "./react/splitStrategy.js"
+    },
     "./react/cache/hooks": {
       "types": "./react/cache/hooks.d.ts",
       "default": "./react/cache/hooks.js"

--- a/packages/convex-helpers/react.ts
+++ b/packages/convex-helpers/react.ts
@@ -21,9 +21,12 @@ import type {
 } from "convex/server";
 import type { Infer } from "convex/values";
 import { getFunctionName } from "convex/server";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { EmptyObject } from "./index.js";
 import type { Value } from "convex/values";
+import { decideSplitAction } from "./react/splitStrategy.js";
+import type { SplitStrategy } from "./react/splitStrategy.js";
+export type { SplitStrategy };
 
 /**
  * Use in place of `useQuery` from "convex/react" to fetch data from a query
@@ -198,6 +201,13 @@ export function makeUseQueryWithStatus(useQueriesHook: typeof useQueries) {
  * To use the cached query helpers, you can use those directly and pass
  * `customPagination: true` in the options.
  *
+ * If your paginated query produces sparse results (many documents read, few
+ * returned — e.g. when using `filterWith` on a stream), consider setting
+ * `splitStrategy: "lazy"`. This prevents the client from eagerly splitting
+ * pages in response to server recommendations, which can recurse and lead to
+ * exponential queries on inactive data ranges. With `"lazy"`, splits only
+ * happen after the backend sends updated data for the page.
+ *
  * Docs copied from {@link usePaginatedQueryOriginal} until `returns` block:
  *
  * @param query - a {@link server.FunctionReference} for the public query to run
@@ -208,7 +218,16 @@ export function makeUseQueryWithStatus(useQueriesHook: typeof useQueries) {
 export function usePaginatedQuery<Query extends PaginatedQueryReference>(
   query: Query,
   args: PaginatedQueryArgs<Query> | "skip",
-  options: { initialNumItems: number },
+  options: {
+    initialNumItems: number;
+    /**
+     * Controls when pages are split in response to "SplitRecommended" from the
+     * server. "eager" (default) splits immediately. "lazy" waits until updated
+     * data arrives for the page before splitting, avoiding splits on inactive
+     * data ranges.
+     */
+    splitStrategy?: SplitStrategy;
+  },
 ): UsePaginatedQueryReturnType<Query> {
   if (
     typeof options?.initialNumItems !== "number" ||
@@ -272,6 +291,14 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
   }
   const convexClient = useConvex();
   const logger = convexClient.logger;
+  const splitStrategy = options.splitStrategy ?? "eager";
+
+  // For lazy split strategy: track result references when SplitRecommended is
+  // first seen. A new reference from the backend (even with identical content)
+  // means the underlying query was re-evaluated, signaling active data.
+  const deferredSplitRefs = useRef<
+    Record<QueryPageKey, PaginationResult<Value>>
+  >({});
 
   const resultsObject = useQueries(currState.queries);
 
@@ -307,6 +334,7 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
             "usePaginatedQuery hit error, resetting pagination state: " +
               currResult.message,
           );
+          deferredSplitRefs.current = {};
           setState(createInitialState);
           return [[], undefined];
         } else {
@@ -319,23 +347,37 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
           resultsObject[ongoingSplit[0]] !== undefined &&
           resultsObject[ongoingSplit[1]] !== undefined
         ) {
-          // Both pages of the split have results now. Swap them in.
+          delete deferredSplitRefs.current[pageKey];
           setState(completeSplitQuery(pageKey));
         }
-      } else if (
-        currResult.splitCursor &&
-        (currResult.pageStatus === "SplitRecommended" ||
-          currResult.pageStatus === "SplitRequired" ||
-          // For custom pagination, we eagerly split the page when it grows.
-          currResult.page.length > options.initialNumItems)
-      ) {
-        setState(
-          splitQuery(
-            pageKey,
-            currResult.splitCursor,
-            currResult.continueCursor,
-          ),
-        );
+      } else {
+        const prevResult = deferredSplitRefs.current[pageKey];
+        const action = decideSplitAction({
+          result: currResult,
+          splitStrategy,
+          initialNumItems: options.initialNumItems,
+          hasPendingLazySplit: prevResult !== undefined,
+          hasNewData: prevResult !== undefined && prevResult !== currResult,
+          customPagination: true,
+        });
+        switch (action.type) {
+          case "split":
+            delete deferredSplitRefs.current[pageKey];
+            setState(
+              splitQuery(pageKey, action.splitCursor, action.continueCursor),
+            );
+            break;
+          case "defer":
+            deferredSplitRefs.current[pageKey] = currResult;
+            break;
+          case "none":
+            // The page no longer has a splitCursor (e.g. the server stopped
+            // recommending a split after data changed), so clean up the ref.
+            if (prevResult !== undefined && !currResult.splitCursor) {
+              delete deferredSplitRefs.current[pageKey];
+            }
+            break;
+        }
       }
       if (currResult.pageStatus === "SplitRequired") {
         // If pageStatus is 'SplitRequired', it means the server was not able to
@@ -353,6 +395,7 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
     options.initialNumItems,
     createInitialState,
     logger,
+    splitStrategy,
   ]);
 
   const statusObject = useMemo(() => {

--- a/packages/convex-helpers/react.ts
+++ b/packages/convex-helpers/react.ts
@@ -296,6 +296,11 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
   // For lazy split strategy: track result references when SplitRecommended is
   // first seen. A new reference from the backend (even with identical content)
   // means the underlying query was re-evaluated, signaling active data.
+  // TODO: On warm-cache remounts, the client re-delivers cached data as a
+  // new reference, which we can't distinguish from a genuine backend update.
+  // This triggers a previously deferred split despite no update from the
+  // backend. Needs a client-side signal (e.g. a delivery version) to
+  // differentiate cache re-delivery from fresh data.
   const deferredSplitRefs = useRef<
     Record<QueryPageKey, PaginationResult<Value>>
   >({});

--- a/packages/convex-helpers/react/cache.ts
+++ b/packages/convex-helpers/react/cache.ts
@@ -1,2 +1,3 @@
 export { ConvexQueryCacheProvider } from "./cache/provider.js";
 export { useQuery, useQueries, usePaginatedQuery } from "./cache/hooks.js";
+export type { SplitStrategy } from "./cache/hooks.js";

--- a/packages/convex-helpers/react/cache/hooks.ts
+++ b/packages/convex-helpers/react/cache/hooks.ts
@@ -420,6 +420,11 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
   // For lazy split strategy: track result references when SplitRecommended is
   // first seen. A new reference from the backend (even with identical content)
   // means the underlying query was re-evaluated, signaling active data.
+  // TODO: On warm-cache remounts, the client re-delivers cached data as a
+  // new reference, which we can't distinguish from a genuine backend update.
+  // This triggers a previously deferred split despite no update from the
+  // backend. Needs a client-side signal (e.g. a delivery version) to
+  // differentiate cache re-delivery from fresh data.
   const deferredSplitRefs = useRef<
     Record<QueryPageKey, PaginationResult<Value>>
   >({});

--- a/packages/convex-helpers/react/cache/hooks.ts
+++ b/packages/convex-helpers/react/cache/hooks.ts
@@ -19,7 +19,7 @@ import type {
   PaginationResult,
 } from "convex/server";
 import { getFunctionName } from "convex/server";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { ConvexQueryCacheContext } from "./provider.js";
 import {
   ConvexError,
@@ -27,6 +27,9 @@ import {
   type Infer,
   type Value,
 } from "convex/values";
+import { decideSplitAction } from "../splitStrategy.js";
+import type { SplitStrategy } from "../splitStrategy.js";
+export type { SplitStrategy };
 
 const uuid =
   typeof crypto !== "undefined" && crypto.randomUUID
@@ -307,6 +310,13 @@ const completeSplitQuery =
  * error or an error associated with too much data, the pagination state will also
  * reset to the first page.
  *
+ * If your paginated query produces sparse results (many documents read, few
+ * returned — e.g. when using `filterWith` on a stream), consider setting
+ * `splitStrategy: "lazy"`. This prevents the client from eagerly splitting
+ * pages in response to server recommendations, which can recurse and lead to
+ * exponential queries on inactive data ranges. With `"lazy"`, splits only
+ * happen after the backend sends updated data for the page.
+ *
  * To learn more about pagination, see [Paginated Queries](https://docs.convex.dev/database/pagination).
  *
  * @param query - A FunctionReference to the public query function to run.
@@ -331,6 +341,13 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
      * Set this to true if you are using the `stream` or `paginator` helpers.
      */
     customPagination?: boolean;
+    /**
+     * Controls when pages are split in response to "SplitRecommended" from the
+     * server. "eager" (default) splits immediately. "lazy" waits until updated
+     * data arrives for the page before splitting, avoiding splits on inactive
+     * data ranges.
+     */
+    splitStrategy?: SplitStrategy;
   },
 ): UsePaginatedQueryReturnType<Query> {
   if (
@@ -398,6 +415,14 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
   }
   const convexClient = useConvex();
   const logger = convexClient.logger;
+  const splitStrategy = options.splitStrategy ?? "eager";
+
+  // For lazy split strategy: track result references when SplitRecommended is
+  // first seen. A new reference from the backend (even with identical content)
+  // means the underlying query was re-evaluated, signaling active data.
+  const deferredSplitRefs = useRef<
+    Record<QueryPageKey, PaginationResult<Value>>
+  >({});
 
   const resultsObject = useQueries(currState.queries);
 
@@ -433,6 +458,7 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
             "usePaginatedQuery hit error, resetting pagination state: " +
               currResult.message,
           );
+          deferredSplitRefs.current = {};
           setState(createInitialState);
           return [[], undefined];
         } else {
@@ -445,27 +471,37 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
           resultsObject[ongoingSplit[0]] !== undefined &&
           resultsObject[ongoingSplit[1]] !== undefined
         ) {
-          // Both pages of the split have results now. Swap them in.
+          delete deferredSplitRefs.current[pageKey];
           setState(completeSplitQuery(pageKey));
         }
-      } else if (
-        currResult.splitCursor &&
-        (currResult.pageStatus === "SplitRecommended" ||
-          currResult.pageStatus === "SplitRequired" ||
-          (options.customPagination
-            ? // For custom pagination, we eagerly split the page when it grows.
-              currResult.page.length > options.initialNumItems
-            : currResult.page.length > options.initialNumItems * 2))
-      ) {
-        // If a single page has more than 1.5x the expected number of items,
-        // or if the server requests a split, split the page into two.
-        setState(
-          splitQuery(
-            pageKey,
-            currResult.splitCursor,
-            currResult.continueCursor,
-          ),
-        );
+      } else {
+        const prevResult = deferredSplitRefs.current[pageKey];
+        const action = decideSplitAction({
+          result: currResult,
+          splitStrategy,
+          initialNumItems: options.initialNumItems,
+          hasPendingLazySplit: prevResult !== undefined,
+          hasNewData: prevResult !== undefined && prevResult !== currResult,
+          customPagination: options.customPagination,
+        });
+        switch (action.type) {
+          case "split":
+            delete deferredSplitRefs.current[pageKey];
+            setState(
+              splitQuery(pageKey, action.splitCursor, action.continueCursor),
+            );
+            break;
+          case "defer":
+            deferredSplitRefs.current[pageKey] = currResult;
+            break;
+          case "none":
+            // The page no longer has a splitCursor (e.g. the server stopped
+            // recommending a split after data changed), so clean up the ref.
+            if (prevResult !== undefined && !currResult.splitCursor) {
+              delete deferredSplitRefs.current[pageKey];
+            }
+            break;
+        }
       }
       if (currResult.pageStatus === "SplitRequired") {
         // If pageStatus is 'SplitRequired', it means the server was not able to
@@ -483,6 +519,7 @@ export function usePaginatedQuery<Query extends PaginatedQueryReference>(
     options.initialNumItems,
     createInitialState,
     logger,
+    splitStrategy,
   ]);
 
   const statusObject = useMemo(() => {

--- a/packages/convex-helpers/react/splitStrategy.test.ts
+++ b/packages/convex-helpers/react/splitStrategy.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import type { PaginationResult } from "convex/server";
+import type { Value } from "convex/values";
+import { decideSplitAction } from "./splitStrategy.js";
+
+const INITIAL_NUM_ITEMS = 10;
+
+function makeResult(
+  overrides: Partial<PaginationResult<Value>> = {},
+): PaginationResult<Value> {
+  return {
+    page: [{ id: 1 }, { id: 2 }],
+    isDone: false,
+    continueCursor: "continue-cursor",
+    ...overrides,
+  };
+}
+
+function decide(
+  overrides: Partial<Parameters<typeof decideSplitAction>[0]> = {},
+) {
+  return decideSplitAction({
+    result: makeResult(),
+    splitStrategy: "eager",
+    initialNumItems: INITIAL_NUM_ITEMS,
+    hasPendingLazySplit: false,
+    hasNewData: false,
+    ...overrides,
+  });
+}
+
+const SPLIT = {
+  type: "split",
+  splitCursor: "split-cursor",
+  continueCursor: "continue-cursor",
+} as const;
+
+describe("decideSplitAction", () => {
+  describe("without splitCursor", () => {
+    test("returns none regardless of strategy", () => {
+      const result = makeResult({ splitCursor: undefined });
+      expect(decide({ result, splitStrategy: "eager" })).toEqual({
+        type: "none",
+      });
+      expect(decide({ result, splitStrategy: "lazy" })).toEqual({
+        type: "none",
+      });
+    });
+  });
+
+  describe("SplitRequired", () => {
+    test("always splits regardless of strategy", () => {
+      const result = makeResult({
+        splitCursor: "split-cursor",
+        pageStatus: "SplitRequired",
+      });
+      expect(decide({ result, splitStrategy: "eager" })).toEqual(SPLIT);
+      expect(decide({ result, splitStrategy: "lazy" })).toEqual(SPLIT);
+    });
+  });
+
+  describe("page size exceeds threshold", () => {
+    test("splits when page is too large (no customPagination)", () => {
+      const page = Array.from(
+        { length: INITIAL_NUM_ITEMS * 2 + 1 },
+        (_, i) => ({ id: i }),
+      );
+      const result = makeResult({ splitCursor: "split-cursor", page });
+      expect(decide({ result, splitStrategy: "lazy" })).toEqual(SPLIT);
+    });
+
+    test("splits when page exceeds initialNumItems with customPagination", () => {
+      const page = Array.from({ length: INITIAL_NUM_ITEMS + 1 }, (_, i) => ({
+        id: i,
+      }));
+      const result = makeResult({ splitCursor: "split-cursor", page });
+      expect(
+        decide({ result, splitStrategy: "lazy", customPagination: true }),
+      ).toEqual(SPLIT);
+    });
+
+    test("does not split when page is within threshold", () => {
+      const page = Array.from(
+        { length: Math.floor(INITIAL_NUM_ITEMS * 1.5) },
+        (_, i) => ({ id: i }),
+      );
+      const result = makeResult({ splitCursor: "split-cursor", page });
+      expect(
+        decide({ result, splitStrategy: "lazy", customPagination: false }),
+      ).toEqual({ type: "none" });
+    });
+  });
+
+  describe("SplitRecommended with eager strategy", () => {
+    test("splits immediately", () => {
+      const result = makeResult({
+        splitCursor: "split-cursor",
+        pageStatus: "SplitRecommended",
+      });
+      expect(decide({ result, splitStrategy: "eager" })).toEqual(SPLIT);
+    });
+  });
+
+  describe("SplitRecommended with lazy strategy", () => {
+    test("defers on first encounter", () => {
+      const result = makeResult({
+        splitCursor: "split-cursor",
+        pageStatus: "SplitRecommended",
+      });
+      expect(decide({ result, splitStrategy: "lazy" })).toEqual({
+        type: "defer",
+      });
+    });
+
+    test("does nothing when waiting and no new data", () => {
+      const result = makeResult({
+        splitCursor: "split-cursor",
+        pageStatus: "SplitRecommended",
+      });
+      expect(
+        decide({
+          result,
+          splitStrategy: "lazy",
+          hasPendingLazySplit: true,
+          hasNewData: false,
+        }),
+      ).toEqual({ type: "none" });
+    });
+
+    test("splits when new data arrives from backend", () => {
+      const result = makeResult({
+        splitCursor: "split-cursor",
+        pageStatus: "SplitRecommended",
+      });
+      expect(
+        decide({
+          result,
+          splitStrategy: "lazy",
+          hasPendingLazySplit: true,
+          hasNewData: true,
+        }),
+      ).toEqual(SPLIT);
+    });
+  });
+});

--- a/packages/convex-helpers/react/splitStrategy.ts
+++ b/packages/convex-helpers/react/splitStrategy.ts
@@ -1,0 +1,65 @@
+import type { PaginationResult } from "convex/server";
+import type { Value } from "convex/values";
+
+export type SplitStrategy = "eager" | "lazy";
+
+export type SplitAction =
+  | { type: "split"; splitCursor: string; continueCursor: string }
+  | { type: "defer" }
+  | { type: "none" };
+
+export function decideSplitAction(opts: {
+  result: PaginationResult<Value>;
+  splitStrategy: SplitStrategy;
+  initialNumItems: number;
+  /** Whether we've already deferred a split for this page and are waiting for new data. */
+  hasPendingLazySplit: boolean;
+  /** Whether the backend has sent a new result for this page since we deferred.
+   * Determined by the caller via reference comparison on the result object. */
+  hasNewData: boolean;
+  customPagination?: boolean;
+}): SplitAction {
+  const { result, splitStrategy, initialNumItems, customPagination } = opts;
+
+  if (!result.splitCursor) {
+    return { type: "none" };
+  }
+
+  if (
+    result.pageStatus === "SplitRequired" ||
+    (customPagination
+      ? result.page.length > initialNumItems
+      : result.page.length > initialNumItems * 2)
+  ) {
+    return {
+      type: "split",
+      splitCursor: result.splitCursor,
+      continueCursor: result.continueCursor,
+    };
+  }
+
+  if (result.pageStatus !== "SplitRecommended") {
+    return { type: "none" };
+  }
+
+  // If we've reached this point, we're handling "SplitRecommended".
+
+  if (splitStrategy === "eager") {
+    return {
+      type: "split",
+      splitCursor: result.splitCursor,
+      continueCursor: result.continueCursor,
+    };
+  }
+  if (!opts.hasPendingLazySplit) {
+    return { type: "defer" };
+  }
+  if (opts.hasNewData) {
+    return {
+      type: "split",
+      splitCursor: result.splitCursor,
+      continueCursor: result.continueCursor,
+    };
+  }
+  return { type: "none" };
+}


### PR DESCRIPTION
When paginated queries produce sparse results, the server repeatedly recommends page splits that can be excessive for inactive data ranges. These split recommendations can also recurse, leading to exponential queries. The new `splitStrategy: "lazy"` option defers acting on SplitRecommended until the backend sends updated data for the page, so splits only happen where the data is actively changing.

Default remains "eager" for backwards compatibility. SplitRequired and page-size-based splits always execute immediately regardless of strategy.

This is meant to address the issue raised in https://github.com/get-convex/convex-backend/issues/443.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
