### PR TITLE
Fix zod4 Convex union type inference for mapped literals

### DIFF
--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -1880,9 +1880,18 @@ export type ZodFromValidatorBase<V extends GenericValidator> =
                                     },
                                   ]
                                 >
-                              : V extends VAny<any, OptionalProperty, any>
-                                ? z.ZodAny
-                                : never;
+                              : V extends VUnion<
+                                    any,
+                                    infer Members extends GenericValidator[],
+                                    OptionalProperty,
+                                    any
+                                  >
+                                ? [GenericValidator] extends [Members[number]]
+                                  ? z.ZodTypeAny
+                                  : ZodValidatorFromConvex<Members[number]>
+                                : V extends VAny<any, OptionalProperty, any>
+                                  ? z.ZodAny
+                                  : never;
 
 type BrandIfBranded<InnerType, Validator extends zCore.SomeType> =
   InnerType extends zCore.$brand<infer Brand>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Describe your PR here. -->

Fixes a regression in `ZodFromValidatorBase` where some valid `VUnion` member lists (notably unions created by spreading a mapped array like `v.union(...Object.values(enum).map(v.literal))`) were inferred as `never` at the type level.

### What changed
- Updated the `ZodFromValidatorBase` union branch in `packages/convex-helpers/server/zod4.ts`:
  - kept the precise tuple handling for `[]`, `[single]`, and `[head, ...rest]`
  - added a fallback for non-tuple `Members extends GenericValidator[]`
  - guarded that fallback to avoid recursive depth explosions when `Members[number]` is effectively `GenericValidator`

### Why
The tests in `zod4.convextozod.test.ts` are correctly asserting that enum-spread unions should produce a corresponding Zod type. This change restores that behavior while preserving compiler stability.

### Validation
- `npm run build`
- `npm run typecheck`
- `cd packages/convex-helpers && npm run typecheck`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8712d68f-d47e-4836-8978-9925690de7ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8712d68f-d47e-4836-8978-9925690de7ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

