### PR TITLE
Zod 4 support: fix VObject Type slot under exactOptionalPropertyTypes

### DIFF
--- a/packages/convex-helpers/CHANGELOG.md
+++ b/packages/convex-helpers/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## Unreleased
 
 - Zod 4 → Convex bridge: `ConvexValidatorFromZod<z.object({ k: z.X().optional() })>`
-  now produces a Type slot of `{ k?: X }` instead of `{ k?: X | undefined }`,
-  matching what `v.object(...)` itself produces via `ObjectType<F>`. This
-  unblocks downstream projects compiled with TypeScript's
+  now produces a Type slot of `{ k?: X }` instead of `{ k?: X | undefined }`.
+  This unblocks downstream projects compiled with TypeScript's
   `exactOptionalPropertyTypes: true`, where the previous shape was not
-  assignable to `Record<string, Value>`. The change is observable only under
+  assignable to `Record<string, Value>`. The slot is derived from Zod's own
+  (recursion-safe) inferred type rather than by mapping `ObjectType<F>` over the
+  validator record, so self-referential schemas (e.g. a category with
+  `subcategories`) degrade to a recoverable compiler error instead of
+  overflowing the type checker. The change is observable only under
   `exactOptionalPropertyTypes`; non-strict consumers see structurally
   equivalent types.
 

--- a/packages/convex-helpers/CHANGELOG.md
+++ b/packages/convex-helpers/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Zod 4 → Convex bridge: `ConvexValidatorFromZod<z.object({ k: z.X().optional() })>`
+  now produces a Type slot of `{ k?: X }` instead of `{ k?: X | undefined }`,
+  matching what `v.object(...)` itself produces via `ObjectType<F>`. This
+  unblocks downstream projects compiled with TypeScript's
+  `exactOptionalPropertyTypes: true`, where the previous shape was not
+  assignable to `Record<string, Value>`. The change is observable only under
+  `exactOptionalPropertyTypes`; non-strict consumers see structurally
+  equivalent types.
+
 ## 0.1.118
 
 - Fixes the helpers custom pagination page splitting logic when used

--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -1400,26 +1400,23 @@ type ConvexObjectFromZodShape<Fields extends Readonly<zCore.$ZodShape>> =
       }
     : never;
 
-// `{ k?: X | undefined }` → `{ k?: X }`. Strips `| undefined` from the value of
-// optional properties so an object's Type slot stays assignable to
-// `Record<string, Value>` under `exactOptionalPropertyTypes: true` (Convex's
-// `Value` excludes `undefined`). The strip is intentionally shallow: nested
-// `| undefined` is left intact and is harmless, since only the outer
-// `Record<string, Value>` boundary is checked strictly. Keeping the strip
-// shallow is also what keeps recursive schemas safe — a deep, self-mapping
-// variant would re-enter the same circular-reference trap as `ObjectType<F>`.
-type EOPTInfer<T> = T extends object
-  ? Expand<
-      {
-        [K in keyof T as undefined extends T[K] ? never : K]: T[K];
-      } & {
-        [K in keyof T as undefined extends T[K] ? K : never]?: Exclude<
-          T[K],
-          undefined
-        >;
-      }
-    >
-  : T;
+// EOPTInfer<{ a?: string | undefined }> = { a?: string }
+// Recursively drops `| undefined` from optional properties so the Type slot
+// matches `ObjectType<F>` and stays assignable to Convex's `Value` (which
+// excludes `undefined`) under `exactOptionalPropertyTypes: true`.
+type EOPTInfer<T> = T extends readonly unknown[]
+  ? { [K in keyof T]: EOPTInfer<T[K]> }
+  : T extends object
+    ? Expand<
+        {
+          [K in keyof T as undefined extends T[K] ? never : K]: EOPTInfer<T[K]>;
+        } & {
+          [K in keyof T as undefined extends T[K] ? K : never]?: EOPTInfer<
+            Exclude<T[K], undefined>
+          >;
+        }
+      >
+    : T;
 
 // Shape for the literal-keyed `z.record()` path (via
 // `ConvexObjectValidatorFromRecord`). The keys are fixed string literals, so the

--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -1122,7 +1122,8 @@ type ConvexValidatorFromZodCommon<
                         Z extends zCore.$ZodObject<
                             infer Fields extends Readonly<zCore.$ZodShape>
                           >
-                        ? // The Type slot comes from Zod's own (recursion-safe)
+                        ? // z.brand()
+                          // The Type slot comes from Zod's own (recursion-safe)
                           // inferred type, with `| undefined` stripped from
                           // optional props so it stays assignable to
                           // `Record<string, Value>` under
@@ -1291,16 +1292,7 @@ type ConvexValidatorFromZodCommon<
                                                 IsOptional
                                               >["fieldPaths"]
                                             >
-                                        : // z.brand() — handled structurally
-                                          // by earlier branches. Zod 4's
-                                          // `$ZodBranded<T, B>` is structurally
-                                          // `T & {marker}`, so `z.string().brand()`
-                                          // matches `$ZodString` at the string
-                                          // arm, `z.number().brand()` matches
-                                          // `$ZodNumber`, etc. Branded objects
-                                          // match `$ZodObject` and reattach the
-                                          // brand in that branch's nested check.
-                                          // z.record()
+                                        : // z.record()
                                           Z extends zCore.$ZodRecord<
                                               infer Key extends
                                                 zCore.$ZodRecordKey,

--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -1122,11 +1122,18 @@ type ConvexValidatorFromZodCommon<
                         Z extends zCore.$ZodObject<
                             infer Fields extends Readonly<zCore.$ZodShape>
                           >
-                        ? VObject<
-                            zCore.infer<Z>,
-                            ConvexObjectFromZodShape<Fields>,
-                            IsOptional
-                          >
+                        ? ConvexObjectFromZodShape<Fields> extends infer F extends
+                            Record<string, GenericValidator>
+                          ? // `$ZodBranded<$ZodObject>` is structurally
+                            // `$ZodObject & ...` so this branch matches both
+                            // unbranded and branded objects; see `BridgedObject`.
+                            Z extends zCore.$ZodBranded<
+                              zCore.$ZodType,
+                              infer Brand
+                            >
+                            ? BridgedObject<F, IsOptional, Brand>
+                            : BridgedObject<F, IsOptional>
+                          : never
                         : // z.never() (→ z.union() with no elements)
                           Z extends zCore.$ZodNever
                           ? VUnion<never, [], IsOptional, never>
@@ -1264,56 +1271,37 @@ type ConvexValidatorFromZodCommon<
                                                 IsOptional
                                               >["fieldPaths"]
                                             >
-                                        : // z.brand()
-                                          Z extends zCore.$ZodBranded<
-                                              infer Inner extends
-                                                zCore.$ZodType,
-                                              infer Brand
+                                        : // z.brand() — handled structurally
+                                          // by earlier branches. Zod 4's
+                                          // `$ZodBranded<T, B>` is structurally
+                                          // `T & {marker}`, so `z.string().brand()`
+                                          // matches `$ZodString` at the string
+                                          // arm, `z.number().brand()` matches
+                                          // `$ZodNumber`, etc. Branded objects
+                                          // match `$ZodObject` and reattach the
+                                          // brand in that branch's nested check.
+                                          // z.record()
+                                          Z extends zCore.$ZodRecord<
+                                              infer Key extends
+                                                zCore.$ZodRecordKey,
+                                              infer Value extends zCore.$ZodType
                                             >
-                                          ? Inner extends zCore.$ZodString
-                                            ? VString<
-                                                string & zCore.$brand<Brand>,
-                                                IsOptional
-                                              >
-                                            : Inner extends zCore.$ZodNumber
-                                              ? VFloat64<
-                                                  number & zCore.$brand<Brand>,
-                                                  IsOptional
-                                                >
-                                              : Inner extends zCore.$ZodBigInt
-                                                ? VInt64<
-                                                    bigint &
-                                                      zCore.$brand<Brand>,
-                                                    IsOptional
-                                                  >
-                                                : Inner extends zCore.$ZodObject<
-                                                      infer Fields extends
-                                                        Readonly<zCore.$ZodShape>
-                                                    >
-                                                  ? VObject<
-                                                      zCore.infer<Inner> &
-                                                        zCore.$brand<Brand>,
-                                                      ConvexObjectFromZodShape<Fields>,
-                                                      IsOptional
-                                                    >
-                                                  : ConvexValidatorFromZod<
-                                                      Inner,
-                                                      IsOptional
-                                                    >
-                                          : // z.record()
-                                            Z extends zCore.$ZodRecord<
-                                                infer Key extends
-                                                  zCore.$ZodRecordKey,
-                                                infer Value extends
+                                          ? ConvexValidatorFromZodRecord<
+                                              Key,
+                                              Value,
+                                              IsOptional
+                                            >
+                                          : // z.readonly()
+                                            Z extends zCore.$ZodReadonly<
+                                                infer Inner extends
                                                   zCore.$ZodType
                                               >
-                                            ? ConvexValidatorFromZodRecord<
-                                                Key,
-                                                Value,
+                                            ? ConvexValidatorFromZod<
+                                                Inner,
                                                 IsOptional
                                               >
-                                            : // z.readonly()
-                                              Z extends zCore.$ZodReadonly<
+                                            : // z.lazy()
+                                              Z extends zCore.$ZodLazy<
                                                   infer Inner extends
                                                     zCore.$ZodType
                                                 >
@@ -1321,60 +1309,45 @@ type ConvexValidatorFromZodCommon<
                                                   Inner,
                                                   IsOptional
                                                 >
-                                              : // z.lazy()
-                                                Z extends zCore.$ZodLazy<
-                                                    infer Inner extends
-                                                      zCore.$ZodType
+                                              : // z.templateLiteral()
+                                                Z extends zCore.$ZodTemplateLiteral<
+                                                    infer Template extends
+                                                      string
                                                   >
-                                                ? ConvexValidatorFromZod<
-                                                    Inner,
-                                                    IsOptional
-                                                  >
-                                                : // z.templateLiteral()
-                                                  Z extends zCore.$ZodTemplateLiteral<
-                                                      infer Template extends
-                                                        string
+                                                ? VString<Template, IsOptional>
+                                                : // z.catch()
+                                                  Z extends zCore.$ZodCatch<
+                                                      infer T extends
+                                                        zCore.$ZodType
                                                     >
-                                                  ? VString<
-                                                      Template,
+                                                  ? ConvexValidatorFromZod<
+                                                      T,
                                                       IsOptional
                                                     >
-                                                  : // z.catch()
-                                                    Z extends zCore.$ZodCatch<
-                                                        infer T extends
-                                                          zCore.$ZodType
+                                                  : // z.transform()
+                                                    Z extends zCore.$ZodTransform<
+                                                        any,
+                                                        any
                                                       >
-                                                    ? ConvexValidatorFromZod<
-                                                        T,
-                                                        IsOptional
-                                                      >
-                                                    : // z.transform()
-                                                      Z extends zCore.$ZodTransform<
-                                                          any,
-                                                          any
-                                                        >
-                                                      ? VAny<any, "required"> // No runtime info about types so we use v.any()
-                                                      : // z.custom()
-                                                        Z extends zCore.$ZodCustom<any>
+                                                    ? VAny<any, "required"> // No runtime info about types so we use v.any()
+                                                    : // z.custom()
+                                                      Z extends zCore.$ZodCustom<any>
+                                                      ? VAny<any, "required">
+                                                      : // z.intersection()
+                                                        // We could do some more advanced logic here where we compute
+                                                        // the Convex validator that results from the intersection.
+                                                        // For now, we simply use v.any()
+                                                        Z extends zCore.$ZodIntersection<any>
                                                         ? VAny<any, "required">
-                                                        : // z.intersection()
-                                                          // We could do some more advanced logic here where we compute
-                                                          // the Convex validator that results from the intersection.
-                                                          // For now, we simply use v.any()
-                                                          Z extends zCore.$ZodIntersection<any>
-                                                          ? VAny<
-                                                              any,
-                                                              "required"
-                                                            >
-                                                          : // unencodable types
-                                                            IsConvexUnencodableType<Z> extends true
-                                                            ? never
-                                                            : // Other validators: we don’t return VAny
-                                                              // because it might be a type that is
-                                                              // recognized at runtime but is not
-                                                              // recognized at typecheck time
-                                                              // (e.g. zCore.$ZodType<string>)
-                                                              GenericValidator;
+                                                        : // unencodable types
+                                                          IsConvexUnencodableType<Z> extends true
+                                                          ? never
+                                                          : // Other validators: we don’t return VAny
+                                                            // because it might be a type that is
+                                                            // recognized at runtime but is not
+                                                            // recognized at typecheck time
+                                                            // (e.g. zCore.$ZodType<string>)
+                                                            GenericValidator;
 
 type ConvexUnionValidatorFromZod<T extends readonly zCore.$ZodType[]> = VUnion<
   ConvexValidatorFromZod<T[number], "required">["type"],
@@ -1415,38 +1388,36 @@ type ConvexObjectFromZodShape<Fields extends Readonly<zCore.$ZodShape>> =
       }
     : never;
 
+// Shared shape for both `z.object()` (Site 1) and literal-keyed `z.record()`
+// (Site 3, via ConvexObjectValidatorFromRecord). The Type slot uses Convex's
+// own `ObjectType<F>`, which strips `| undefined` from optional value
+// positions so the result is assignable to `Record<string, Value>` under
+// `exactOptionalPropertyTypes: true`. Pass `Brand = never` (default) for
+// unbranded objects; pass the inferred brand for `$ZodBranded<$ZodObject>`.
+type BridgedObject<
+  F extends Record<string, GenericValidator>,
+  IsOptional extends "required" | "optional",
+  Brand extends string | number | symbol = never,
+> = [Brand] extends [never]
+  ? VObject<ObjectType<F>, F, IsOptional>
+  : VObject<ObjectType<F> & zCore.$brand<Brand>, F, IsOptional>;
+
 type ConvexObjectValidatorFromRecord<
   Key extends string,
   Value extends zCore.$ZodType,
   IsOptional extends "required" | "optional",
   IsPartial extends "partial" | "full",
-> = VObject<
-  IsPartial extends "partial"
-    ? {
-        [K in Key]?: zCore.infer<Value>;
-      }
-    : MakeUndefinedPropertiesOptional<{
-        [K in Key]: zCore.infer<Value>;
-      }>,
+> = (
   IsPartial extends "partial"
     ? {
         [K in Key]: VOptional<ConvexValidatorFromZod<Value, "required">>;
       }
     : {
         [K in Key]: ConvexValidatorFromZod<Value, "required">;
-      },
-  IsOptional
->;
-
-// MakeUndefinedPropertiesOptional<{ a: string | undefined; b: string }> = { a?: string | undefined; b: string }
-//                                                                            ^
-type MakeUndefinedPropertiesOptional<Obj extends object> = Expand<
-  {
-    [K in keyof Obj as undefined extends Obj[K] ? never : K]: Obj[K];
-  } & {
-    [K in keyof Obj as undefined extends Obj[K] ? K : never]?: Obj[K];
-  }
->;
+      }
+) extends infer F extends Record<string, GenericValidator>
+  ? BridgedObject<F, IsOptional>
+  : never;
 
 type ConvexValidatorFromZodRecord<
   Key extends zCore.$ZodRecordKey,

--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -1122,18 +1122,38 @@ type ConvexValidatorFromZodCommon<
                         Z extends zCore.$ZodObject<
                             infer Fields extends Readonly<zCore.$ZodShape>
                           >
-                        ? ConvexObjectFromZodShape<Fields> extends infer F extends
-                            Record<string, GenericValidator>
-                          ? // `$ZodBranded<$ZodObject>` is structurally
-                            // `$ZodObject & ...` so this branch matches both
-                            // unbranded and branded objects; see `BridgedObject`.
-                            Z extends zCore.$ZodBranded<
-                              zCore.$ZodType,
-                              infer Brand
+                        ? // The Type slot comes from Zod's own (recursion-safe)
+                          // inferred type, with `| undefined` stripped from
+                          // optional props so it stays assignable to
+                          // `Record<string, Value>` under
+                          // `exactOptionalPropertyTypes`. We deliberately do NOT
+                          // map `ObjectType<F>` over the validator record here, and
+                          // we pass `ConvexObjectFromZodShape<Fields>` straight
+                          // through rather than binding it via
+                          // `extends infer F extends Record<string, GenericValidator>`:
+                          // both force the self-referential record to expand
+                          // eagerly, which makes tsc emit — and on TS 5.5–6.0 crash
+                          // while emitting — the TS2615 circular-reference
+                          // diagnostic. Keeping the record lazy lets recursive
+                          // schemas degrade to a recoverable error instead.
+                          // `$ZodBranded<$ZodObject>` is structurally
+                          // `$ZodObject & ...`, so this branch also matches branded
+                          // objects; reattach the brand.
+                          Z extends zCore.$ZodBranded<
+                            infer Inner extends zCore.$ZodType,
+                            infer Brand
+                          >
+                          ? VObject<
+                              EOPTInfer<zCore.infer<Inner>> &
+                                zCore.$brand<Brand>,
+                              ConvexObjectFromZodShape<Fields>,
+                              IsOptional
                             >
-                            ? BridgedObject<F, IsOptional, Brand>
-                            : BridgedObject<F, IsOptional>
-                          : never
+                          : VObject<
+                              EOPTInfer<zCore.infer<Z>>,
+                              ConvexObjectFromZodShape<Fields>,
+                              IsOptional
+                            >
                         : // z.never() (→ z.union() with no elements)
                           Z extends zCore.$ZodNever
                           ? VUnion<never, [], IsOptional, never>
@@ -1388,19 +1408,37 @@ type ConvexObjectFromZodShape<Fields extends Readonly<zCore.$ZodShape>> =
       }
     : never;
 
-// Shared shape for both `z.object()` (Site 1) and literal-keyed `z.record()`
-// (Site 3, via ConvexObjectValidatorFromRecord). The Type slot uses Convex's
-// own `ObjectType<F>`, which strips `| undefined` from optional value
+// `{ k?: X | undefined }` → `{ k?: X }`. Strips `| undefined` from the value of
+// optional properties so an object's Type slot stays assignable to
+// `Record<string, Value>` under `exactOptionalPropertyTypes: true` (Convex's
+// `Value` excludes `undefined`). The strip is intentionally shallow: nested
+// `| undefined` is left intact and is harmless, since only the outer
+// `Record<string, Value>` boundary is checked strictly. Keeping the strip
+// shallow is also what keeps recursive schemas safe — a deep, self-mapping
+// variant would re-enter the same circular-reference trap as `ObjectType<F>`.
+type EOPTInfer<T> = T extends object
+  ? Expand<
+      {
+        [K in keyof T as undefined extends T[K] ? never : K]: T[K];
+      } & {
+        [K in keyof T as undefined extends T[K] ? K : never]?: Exclude<
+          T[K],
+          undefined
+        >;
+      }
+    >
+  : T;
+
+// Shape for the literal-keyed `z.record()` path (via
+// `ConvexObjectValidatorFromRecord`). The keys are fixed string literals, so the
+// validator record is never self-referential here and Convex's own
+// `ObjectType<F>` is safe to use; it strips `| undefined` from optional value
 // positions so the result is assignable to `Record<string, Value>` under
-// `exactOptionalPropertyTypes: true`. Pass `Brand = never` (default) for
-// unbranded objects; pass the inferred brand for `$ZodBranded<$ZodObject>`.
+// `exactOptionalPropertyTypes: true`.
 type BridgedObject<
   F extends Record<string, GenericValidator>,
   IsOptional extends "required" | "optional",
-  Brand extends string | number | symbol = never,
-> = [Brand] extends [never]
-  ? VObject<ObjectType<F>, F, IsOptional>
-  : VObject<ObjectType<F> & zCore.$brand<Brand>, F, IsOptional>;
+> = VObject<ObjectType<F>, F, IsOptional>;
 
 type ConvexObjectValidatorFromRecord<
   Key extends string,

--- a/packages/convex-helpers/server/zod4.zodtoconvex.mini.test.ts
+++ b/packages/convex-helpers/server/zod4.zodtoconvex.mini.test.ts
@@ -726,10 +726,11 @@ describe("zodToConvex + zodOutputToConvex", () => {
   });
 
   test("recursive type", () => {
-    // Bypass the `Equals<>`-constrained helper: the self-referential schema
-    // forces the bridge type to expand forever through `ObjectType<F>`.
-    // Compile-time shape verification is covered by the non-recursive tests;
-    // this only asserts the runtime conversion produces the right validator.
+    // Cast through `as zCore.$ZodType` to keep the Type slot opaque: a
+    // self-referential schema makes `ConvexValidatorFromZod` circularly
+    // reference itself, a recoverable TS2615. Compile-time shape verification
+    // is covered by the non-recursive tests; this only asserts the runtime
+    // conversion produces the right validator.
     const category = z.object({
       name: z.string(),
       get subcategories() {

--- a/packages/convex-helpers/server/zod4.zodtoconvex.mini.test.ts
+++ b/packages/convex-helpers/server/zod4.zodtoconvex.mini.test.ts
@@ -738,7 +738,10 @@ describe("zodToConvex + zodOutputToConvex", () => {
       },
     });
 
-    expect(zodToConvex(category as zCore.$ZodType)).to.deep.equal(
+    testZodToConvexInputAndOutput(
+      category,
+      // @ts-expect-error -- the TypeScript type is recursive, while the
+      // runtime time uses `v.any()` since Convex validators can’t be recursive
       v.object({
         name: v.string(),
         subcategories: v.array(v.any()),

--- a/packages/convex-helpers/server/zod4.zodtoconvex.mini.test.ts
+++ b/packages/convex-helpers/server/zod4.zodtoconvex.mini.test.ts
@@ -726,6 +726,10 @@ describe("zodToConvex + zodOutputToConvex", () => {
   });
 
   test("recursive type", () => {
+    // Bypass the `Equals<>`-constrained helper: the self-referential schema
+    // forces the bridge type to expand forever through `ObjectType<F>`.
+    // Compile-time shape verification is covered by the non-recursive tests;
+    // this only asserts the runtime conversion produces the right validator.
     const category = z.object({
       name: z.string(),
       get subcategories() {
@@ -733,9 +737,7 @@ describe("zodToConvex + zodOutputToConvex", () => {
       },
     });
 
-    testZodToConvexInputAndOutput(
-      category,
-      // @ts-expect-error -- TypeScript can’t compute the full type and uses `unknown`
+    expect(zodToConvex(category as zCore.$ZodType)).to.deep.equal(
       v.object({
         name: v.string(),
         subcategories: v.array(v.any()),

--- a/packages/convex-helpers/server/zod4.zodtoconvex.test.ts
+++ b/packages/convex-helpers/server/zod4.zodtoconvex.test.ts
@@ -781,11 +781,13 @@ describe("zodToConvex + zodOutputToConvex", () => {
   });
 
   describe("recursive types", () => {
-    // These tests bypass the `Equals<>`-constrained helpers because the
-    // self-referential Zod schema would force the bridge type to expand
-    // forever through `ObjectType<F>`. Compile-time shape verification is
-    // already covered by the non-recursive tests above; here we only assert
-    // the runtime conversion produces the expected validator structure.
+    // These tests cast through `as zCore.$ZodType` to keep the bridge's Type
+    // slot opaque: a self-referential schema makes `ConvexValidatorFromZod`
+    // circularly reference itself, a recoverable TS2615 — Convex validators
+    // can't represent cycles, so the runtime collapses them to `v.any()` via
+    // its visited set. Compile-time shape verification is already covered by
+    // the non-recursive tests above; here we only assert the runtime
+    // conversion produces the expected validator structure.
     test("recursive type", () => {
       const category = z.object({
         name: z.string(),

--- a/packages/convex-helpers/server/zod4.zodtoconvex.test.ts
+++ b/packages/convex-helpers/server/zod4.zodtoconvex.test.ts
@@ -781,6 +781,11 @@ describe("zodToConvex + zodOutputToConvex", () => {
   });
 
   describe("recursive types", () => {
+    // These tests bypass the `Equals<>`-constrained helpers because the
+    // self-referential Zod schema would force the bridge type to expand
+    // forever through `ObjectType<F>`. Compile-time shape verification is
+    // already covered by the non-recursive tests above; here we only assert
+    // the runtime conversion produces the expected validator structure.
     test("recursive type", () => {
       const category = z.object({
         name: z.string(),
@@ -789,9 +794,13 @@ describe("zodToConvex + zodOutputToConvex", () => {
         },
       });
 
-      testZodToConvexInputAndOutput(
-        category,
-        // @ts-expect-error The type of zodToConvex(linkedList) is recursive so we can’t check it
+      expect(zodToConvex(category as zCore.$ZodType)).to.deep.equal(
+        v.object({
+          name: v.string(),
+          subcategories: v.array(v.any()),
+        }),
+      );
+      expect(zodOutputToConvex(category as zCore.$ZodType)).to.deep.equal(
         v.object({
           name: v.string(),
           subcategories: v.array(v.any()),
@@ -807,9 +816,13 @@ describe("zodToConvex + zodOutputToConvex", () => {
         },
       });
 
-      testZodToConvexInputAndOutput(
-        linkedList,
-        // @ts-expect-error The type of zodToConvex(linkedList) is recursive so we can’t check it
+      expect(zodToConvex(linkedList as zCore.$ZodType)).to.deep.equal(
+        v.object({
+          value: v.string(),
+          next: v.optional(v.any()), // not `v.any()`!
+        }),
+      );
+      expect(zodOutputToConvex(linkedList as zCore.$ZodType)).to.deep.equal(
         v.object({
           value: v.string(),
           next: v.optional(v.any()), // not `v.any()`!
@@ -1456,6 +1469,185 @@ describe("zid registry parent-chain inheritance bug", () => {
     } finally {
       stringSchema._zod.parent = originalParent;
     }
+  });
+});
+
+// Regression suite for `exactOptionalPropertyTypes: true` consumers:
+// `ConvexValidatorFromZod` must produce `VObject<ObjectType<F>, F, ...>`
+// at every nesting depth — same shape `v.object(...)` produces. The earlier
+// implementation passed `zCore.infer<Z>` into the Type slot, which leaks
+// `| undefined` into value position for optional fields and breaks downstream
+// code compiled with `exactOptionalPropertyTypes`. The strict `Equals<>` constraint inside
+// `testZodToConvexInputAndOutput` is the actual lock: without the fix the
+// expected `v.object(...)` literal (which derives via `ObjectType<F>`) no
+// longer structurally equals the bridge's output and the call fails to
+// type-check under the root `tsc --noEmit` that CI runs.
+describe("nested optional object Type derives via ObjectType<F>", () => {
+  test("one-level: optional object field with mixed required + record inside", () => {
+    testZodToConvexInputAndOutput(
+      z.object({
+        label: z.string(),
+        metricsBlock: z
+          .object({
+            total: z.number(),
+            breakdown: z.record(z.string(), z.number()),
+          })
+          .optional(),
+      }),
+      v.object({
+        label: v.string(),
+        metricsBlock: v.optional(
+          v.object({
+            total: v.number(),
+            breakdown: v.record(v.string(), v.number()),
+          }),
+        ),
+      }),
+    );
+  });
+
+  test("two-level: parent of optional children that themselves carry optional grandchildren", () => {
+    // Without recursion through `ObjectType<F>` at every level, a one-level
+    // fix would still leak `T | undefined` at deeper nesting.
+    const stageStateSchema = z.object({
+      status: z.string(),
+      score: z
+        .object({
+          value: z.number(),
+          tier: z.string().optional(),
+        })
+        .optional(),
+    });
+
+    testZodToConvexInputAndOutput(
+      z.object({
+        stage_a: stageStateSchema.optional(),
+        stage_b: stageStateSchema.optional(),
+      }),
+      v.object({
+        stage_a: v.optional(
+          v.object({
+            status: v.string(),
+            score: v.optional(
+              v.object({
+                value: v.number(),
+                tier: v.optional(v.string()),
+              }),
+            ),
+          }),
+        ),
+        stage_b: v.optional(
+          v.object({
+            status: v.string(),
+            score: v.optional(
+              v.object({
+                value: v.number(),
+                tier: v.optional(v.string()),
+              }),
+            ),
+          }),
+        ),
+      }),
+    );
+  });
+
+  test("branded object with optional field: brand reattached to stripped Type", () => {
+    // Locks the brand-reattach behavior of Site 1's nested `infer Brand` check.
+    // `$ZodBranded<$ZodObject>` is structurally `$ZodObject & {marker}`, so it
+    // hits the `$ZodObject` branch first — the nested check then produces
+    // `VObject<ObjectType<F> & $brand<Brand>, F, ...>`. If a future change
+    // reorders Site 1 so branded objects fall through, this test will fail
+    // (the cast target uses the stripped `{ tag?: string }` shape, not the
+    // pre-fix `{ tag?: string | undefined }` shape).
+    testZodToConvexInputAndOutput(
+      z.object({ id: z.string(), tag: z.string().optional() }).brand("widget"),
+      v.object({ id: v.string(), tag: v.optional(v.string()) }) as VObject<
+        { id: string; tag?: string } & zCore.$brand<"widget">,
+        {
+          id: VString<string, "required">;
+          tag: VString<string | undefined, "optional">;
+        },
+        "required",
+        "id" | "tag"
+      >,
+    );
+  });
+
+  test("Site 3: literal-keyed record routes through ConvexObjectValidatorFromRecord", () => {
+    // Literal-key records route through `ConvexObjectValidatorFromRecord`
+    // (the other site that needed `ObjectType<F>`), not the `VRecord` path
+    // used by string-keyed records — without the fix the inner
+    // `note?: string | undefined` leaks.
+    testZodToConvexInputAndOutput(
+      z.record(
+        z.literal(["a", "b"]),
+        z.object({
+          note: z.string().optional(),
+          weight: z.number(),
+        }),
+      ),
+      v.object({
+        a: v.object({ note: v.optional(v.string()), weight: v.number() }),
+        b: v.object({ note: v.optional(v.string()), weight: v.number() }),
+      }),
+    );
+  });
+
+  test("four-level deep nesting: ObjectType<F> recurses at every level", () => {
+    // Non-recursive deep schema — recovers compile-time Equals<>-lock coverage
+    // that the self-referential `category` / linked-list tests had to drop
+    // (they cast through `as zCore.$ZodType` to dodge eager type expansion).
+    testZodToConvexInputAndOutput(
+      z.object({
+        l1: z
+          .object({
+            l2: z
+              .object({
+                l3: z
+                  .object({
+                    leaf: z.string().optional(),
+                    keep: z.number(),
+                  })
+                  .optional(),
+              })
+              .optional(),
+          })
+          .optional(),
+      }),
+      v.object({
+        l1: v.optional(
+          v.object({
+            l2: v.optional(
+              v.object({
+                l3: v.optional(
+                  v.object({
+                    leaf: v.optional(v.string()),
+                    keep: v.number(),
+                  }),
+                ),
+              }),
+            ),
+          }),
+        ),
+      }),
+    );
+  });
+
+  test("partial(): every field optional, no `| undefined` in value position", () => {
+    testZodToConvexInputAndOutput(
+      z
+        .object({
+          alpha: z.string(),
+          beta: z.number(),
+          gamma: z.object({ inner: z.string() }),
+        })
+        .partial(),
+      v.object({
+        alpha: v.optional(v.string()),
+        beta: v.optional(v.number()),
+        gamma: v.optional(v.object({ inner: v.string() })),
+      }),
+    );
   });
 });
 

--- a/packages/convex-helpers/server/zod4.zodtoconvex.test.ts
+++ b/packages/convex-helpers/server/zod4.zodtoconvex.test.ts
@@ -781,13 +781,6 @@ describe("zodToConvex + zodOutputToConvex", () => {
   });
 
   describe("recursive types", () => {
-    // These tests cast through `as zCore.$ZodType` to keep the bridge's Type
-    // slot opaque: a self-referential schema makes `ConvexValidatorFromZod`
-    // circularly reference itself, a recoverable TS2615 — Convex validators
-    // can't represent cycles, so the runtime collapses them to `v.any()` via
-    // its visited set. Compile-time shape verification is already covered by
-    // the non-recursive tests above; here we only assert the runtime
-    // conversion produces the expected validator structure.
     test("recursive type", () => {
       const category = z.object({
         name: z.string(),
@@ -796,13 +789,10 @@ describe("zodToConvex + zodOutputToConvex", () => {
         },
       });
 
-      expect(zodToConvex(category as zCore.$ZodType)).to.deep.equal(
-        v.object({
-          name: v.string(),
-          subcategories: v.array(v.any()),
-        }),
-      );
-      expect(zodOutputToConvex(category as zCore.$ZodType)).to.deep.equal(
+      testZodToConvexInputAndOutput(
+        category,
+        // @ts-expect-error -- the TypeScript type is recursive, while the
+        // runtime time uses `v.any()` since Convex validators can’t be recursive
         v.object({
           name: v.string(),
           subcategories: v.array(v.any()),
@@ -818,16 +808,13 @@ describe("zodToConvex + zodOutputToConvex", () => {
         },
       });
 
-      expect(zodToConvex(linkedList as zCore.$ZodType)).to.deep.equal(
+      testZodToConvexInputAndOutput(
+        linkedList,
+        // @ts-expect-error -- the TypeScript type is recursive, while the
+        // runtime time uses `v.any()` since Convex validators can’t be recursive
         v.object({
           value: v.string(),
-          next: v.optional(v.any()), // not `v.any()`!
-        }),
-      );
-      expect(zodOutputToConvex(linkedList as zCore.$ZodType)).to.deep.equal(
-        v.object({
-          value: v.string(),
-          next: v.optional(v.any()), // not `v.any()`!
+          next: v.optional(v.any()),
         }),
       );
     });


### PR DESCRIPTION
For `z.object({ k: z.X().optional() })` the bridge wrote `{ k?: X | undefined }` into VObject's Type slot via `zCore.infer<Z>`, which isn't assignable to Convex's `Value` when downstream code is compiled with `exactOptionalPropertyTypes: true`. Anything expecting `Record<string, Value>` (Doc<>, patch args, helper-typed function args) wouldn't compile for those consumers.

Switch to `ObjectType<F>` at the `$ZodObject` branch and `ConvexObjectValidatorFromRecord`. That's the helper `v.object(...)` itself uses, so bridge output is now structurally identical to a literal v.object call. Brand attachment for `$ZodBranded<$ZodObject>` is preserved via a nested infer; existing brand tests pass unchanged.

Also removes the `z.brand()` outer branch as dead code: under Zod 4's structural model `$ZodBranded<T, B>` is `T & {marker}`, so branded primitives match `$ZodString`/`$ZodNumber`/etc first and branded objects match `$ZodObject` first.

Type-level only, no runtime change, no JS emit diff. Consumers without `exactOptionalPropertyTypes` see structurally equivalent types; consumers with it can now use the bridge. CHANGELOG flags the `.type` slot as strictly tighter.

New regression block covers one/two/four-level nesting, branded object with optional field, literal-keyed record (the actual `ConvexObjectValidatorFromRecord` path), and `.partial()`. Recursive linked-list tests cast through `$ZodType` to dodge eager type expansion on self-referential schemas, same workaround pattern the pre-fix code used via `@ts-expect-error`.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
