### PR TITLE
cli: add timeout and clear error when the deployment is unreachable (open-api-spec / ts-api-spec)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2205,9 +2205,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2225,9 +2222,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2245,9 +2239,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2265,9 +2256,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,9 +2273,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2305,9 +2290,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7460,9 +7442,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7484,9 +7463,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7508,9 +7484,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7532,9 +7505,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/packages/convex-helpers/cli/openApiSpec.ts
+++ b/packages/convex-helpers/cli/openApiSpec.ts
@@ -34,8 +34,18 @@ export const openApiSpec = new Command("open-api-spec")
       "Get the function spec for your configured project's prod deployment.",
     ).default(undefined),
   )
+  .addOption(
+    new Option(
+      "--timeout <seconds>",
+      "Maximum time in seconds to wait when retrieving the function spec from your Convex deployment.",
+    ).default(120),
+  )
   .action(async (options) => {
-    const content = getFunctionSpec(options.prod, options.inputFile);
+    const content = getFunctionSpec(
+      options.prod,
+      options.inputFile,
+      Number(options.timeout),
+    );
     const baseOutputPath =
       options.outputFile ?? `convex-spec-${Date.now().valueOf()}`;
     const outputPath =

--- a/packages/convex-helpers/cli/tsApiSpec.ts
+++ b/packages/convex-helpers/cli/tsApiSpec.ts
@@ -36,8 +36,18 @@ export const tsApiSpec = new Command("ts-api-spec")
       "Include internal functions from your Convex deployment.",
     ).default(false),
   )
+  .addOption(
+    new Option(
+      "--timeout <seconds>",
+      "Maximum time in seconds to wait when retrieving the function spec from your Convex deployment.",
+    ).default(120),
+  )
   .action(async (options) => {
-    const content = getFunctionSpec(options.prod, options.inputFile);
+    const content = getFunctionSpec(
+      options.prod,
+      options.inputFile,
+      Number(options.timeout),
+    );
     const baseOutputPath =
       options.outputFile ?? `convexApi${Date.now().valueOf()}`;
     const outputPath = baseOutputPath.endsWith(".ts")

--- a/packages/convex-helpers/cli/utils.ts
+++ b/packages/convex-helpers/cli/utils.ts
@@ -27,6 +27,14 @@ export function getFunctionSpec(
   filePath?: string,
   timeoutSeconds: number = 120,
 ) {
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+    console.error(
+      chalk.red(
+        `Invalid --timeout value: expected a positive number of seconds.`,
+      ),
+    );
+    process.exit(1);
+  }
   if (filePath && prod) {
     console.error(`To use the prod flag, you can't provide a file path`);
     process.exit(1);

--- a/packages/convex-helpers/cli/utils.ts
+++ b/packages/convex-helpers/cli/utils.ts
@@ -22,7 +22,11 @@ export type AnalyzedFunction = {
   returns: ValidatorJSON | null;
 };
 
-export function getFunctionSpec(prod?: boolean, filePath?: string) {
+export function getFunctionSpec(
+  prod?: boolean,
+  filePath?: string,
+  timeoutSeconds: number = 120,
+) {
   if (filePath && prod) {
     console.error(`To use the prod flag, you can't provide a file path`);
     process.exit(1);
@@ -45,11 +49,25 @@ export function getFunctionSpec(prod?: boolean, filePath?: string) {
       const result = spawnSync(npxCmd, ["convex", "function-spec", ...flags], {
         stdio: ["inherit", outputFd, "pipe"],
         encoding: "utf-8",
+        timeout: timeoutSeconds * 1000,
         ...extraOpts,
       });
 
       fs.closeSync(outputFd);
 
+      if (
+        result.error &&
+        (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT"
+      ) {
+        throw new Error(
+          `Timed out after ${timeoutSeconds}s waiting for \`npx convex function-spec\`. ` +
+            "Check that your deployment is reachable (e.g. `npx convex dev` is running, " +
+            "or pass --prod for your production deployment), or increase --timeout.",
+        );
+      }
+      if (result.error) {
+        throw result.error;
+      }
       if (result.status !== 0) {
         throw new Error(result.stderr || "Failed without error message");
       }


### PR DESCRIPTION
Fixes #877

## Problem

`npx convex-helpers open-api-spec` (and `ts-api-spec`) hangs forever with no output when the configured deployment can't be reached — e.g. running against a local deployment while `npx convex dev` isn't running.

## Cause

`getFunctionSpec` in `cli/utils.ts` shells out to `npx convex function-spec` via `spawnSync` with no `timeout`, so if the underlying CLI blocks on the network, the command blocks indefinitely.

## Change

- Add a `timeout` to the `spawnSync` call (default **120s**).
- Expose it as `--timeout <seconds>` on both `open-api-spec` and `ts-api-spec`.
- On timeout, fail with an actionable message (check that `npx convex dev` is running / use `--prod` / raise `--timeout`) instead of hanging silently.
- Also surface other `spawnSync` errors (`result.error` was previously ignored — only `status` was checked).

## Testing

- `npm run typecheck` passes (package).
- `npx vitest run cli`: 8/8 tests pass.
- Repro: with an unreachable deployment, the command now exits after the timeout with the error message instead of hanging.