### PR TITLE
support commitTs in convex 1.43.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@vitejs/plugin-react": "6.0.1",
         "@vitest/coverage-v8": "4.1.5",
         "chokidar-cli": "3.0.0",
-        "convex": "1.38.0",
+        "convex": "1.43.0",
         "convex-test": "0.0.51",
         "eslint": "9.39.4",
         "eslint-plugin-react": "7.37.5",
@@ -4615,15 +4615,15 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.38.0.tgz",
-      "integrity": "sha512-122AC6y5lUS7mr39cluLw9+TOtRX5d/XxeivHhHObs/NTXoVvOnIgDzexVcxaz6Rk0oLFSoydSR1rDCltEz/0A==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.43.0.tgz",
+      "integrity": "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.21.0"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -11102,9 +11102,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@vitejs/plugin-react": "6.0.1",
     "@vitest/coverage-v8": "4.1.5",
     "chokidar-cli": "3.0.0",
-    "convex": "1.38.0",
+    "convex": "1.43.0",
     "convex-test": "0.0.51",
     "eslint": "9.39.4",
     "eslint-plugin-react": "7.37.5",

--- a/packages/convex-helpers/CHANGELOG.md
+++ b/packages/convex-helpers/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Support the new `db.vars.commitTs` variable and `v.commitTs()` validator added in
+  convex 1.43.0.
 - `convex-helpers/server/compare` is deprecated and now re-exports
   `compareValues` from `convex/values`. There may be small differences in behavior in
   uncommon cases (NaNs, negative zero, etc.) compared with the previous implementation.

--- a/packages/convex-helpers/cli/openApiSpec.ts
+++ b/packages/convex-helpers/cli/openApiSpec.ts
@@ -66,6 +66,7 @@ function generateSchemaFromValidator(validatorJson: ValidatorJSON): string {
     case "number":
       return "type: number";
     case "bigint":
+    case "commitTs":
       return "type: integer\nformat: int64";
     case "boolean":
       return "type: boolean";

--- a/packages/convex-helpers/cli/tsApiSpec.ts
+++ b/packages/convex-helpers/cli/tsApiSpec.ts
@@ -68,6 +68,7 @@ function generateArgsType(argsJson: ValidatorJSON): string {
     case "number":
       return "number";
     case "bigint":
+    case "commitTs":
       return "bigint";
     case "boolean":
       return "boolean";

--- a/packages/convex-helpers/package.json
+++ b/packages/convex-helpers/package.json
@@ -164,7 +164,7 @@
   "homepage": "https://github.com/get-convex/convex-helpers/tree/main/packages/convex-helpers/README.md",
   "peerDependencies": {
     "@standard-schema/spec": "^1.0.0",
-    "convex": "^1.32.0",
+    "convex": "^1.43.0",
     "hono": "^4.0.5",
     "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
     "typescript": "^5.5 || ^6.0.0",

--- a/packages/convex-helpers/server/rowLevelSecurity.ts
+++ b/packages/convex-helpers/server/rowLevelSecurity.ts
@@ -276,6 +276,7 @@ class WrapWriter<
   ctx: Ctx;
   db: GenericDatabaseWriter<DataModel>;
   system: GenericDatabaseWriter<DataModel>["system"];
+  vars: GenericDatabaseWriter<DataModel>["vars"];
   reader: GenericDatabaseReader<DataModel>;
   rules: Rules<Ctx, DataModel>;
   config: RLSConfig;
@@ -299,6 +300,7 @@ class WrapWriter<
     this.ctx = ctx;
     this.db = db;
     this.system = db.system;
+    this.vars = db.vars;
     this.reader = new WrapReader(ctx, db, rules, config);
     this.rules = rules;
     this.config = config ?? { defaultPolicy: "allow" };

--- a/packages/convex-helpers/server/triggers.ts
+++ b/packages/convex-helpers/server/triggers.ts
@@ -166,6 +166,7 @@ export class DatabaseWriterWithTriggers<
     isWithinTrigger: boolean = false,
   ) {
     this.system = innerDb.system;
+    this.vars = innerDb.vars;
     this.writer = writerWithTriggers(ctx, innerDb, triggers, isWithinTrigger);
   }
 
@@ -236,6 +237,8 @@ export class DatabaseWriterWithTriggers<
   }
 
   system: GenericDatabaseWriter<DataModel>["system"];
+
+  vars: GenericDatabaseWriter<DataModel>["vars"];
 }
 
 export function writerWithTriggers<
@@ -397,6 +400,7 @@ export function writerWithTriggers<
     get: innerDb.get.bind(innerDb),
     query: innerDb.query.bind(innerDb),
     normalizeId: innerDb.normalizeId.bind(innerDb),
+    vars: innerDb.vars,
   };
 }
 

--- a/packages/convex-helpers/server/zod3.test.ts
+++ b/packages/convex-helpers/server/zod3.test.ts
@@ -25,7 +25,7 @@ import {
 } from "./zod3.js";
 import { customCtx } from "./customFunctions.js";
 import type { VString, VFloat64, VObject, VId, Infer } from "convex/values";
-import { v } from "convex/values";
+import { CommitTsPlaceholder, v } from "convex/values";
 import { z } from "zod/v3";
 
 // This is an example of how to make a version of `zid` that
@@ -1010,6 +1010,14 @@ test("convexToZod basic types", () => {
   expect(convexToZod(v.null()).constructor.name).toBe("ZodNull");
   expect(convexToZod(v.any()).constructor.name).toBe("ZodAny");
   expect(convexToZod(v.id("users")).constructor.name).toBe("Zid");
+});
+
+test("convexToZod commitTs", () => {
+  const _expected = z.union([z.bigint(), z.instanceof(CommitTsPlaceholder)]);
+  const validator = convexToZod(v.commitTs());
+  expectTypeOf(validator).toEqualTypeOf<typeof _expected>();
+  expect(validator.safeParse(1n).success).toBe(true);
+  expect(validator.safeParse(new CommitTsPlaceholder()).success).toBe(true);
 });
 
 test("convexToZod complex types", () => {

--- a/packages/convex-helpers/server/zod3.ts
+++ b/packages/convex-helpers/server/zod3.ts
@@ -13,6 +13,7 @@ import type {
   VUnion,
   VFloat64,
   VInt64,
+  VCommitTs,
   VBoolean,
   VNull,
   VLiteral,
@@ -22,7 +23,7 @@ import type {
   Validator,
   VRecord,
 } from "convex/values";
-import { ConvexError, v } from "convex/values";
+import { CommitTsPlaceholder, ConvexError, v } from "convex/values";
 import type {
   FunctionVisibility,
   GenericDataModel,
@@ -1610,50 +1611,57 @@ type ZodFromValidatorBase<V extends GenericValidator> =
         ? z.ZodNumber
         : V extends VInt64<any, any>
           ? z.ZodBigInt
-          : V extends VBoolean<any, any>
-            ? z.ZodBoolean
-            : V extends VNull<any, any>
-              ? z.ZodNull
-              : V extends VLiteral<infer T, any>
-                ? z.ZodLiteral<T>
-                : V extends VObject<any, infer Fields, any, any>
-                  ? z.ZodObject<
-                      {
-                        [K in keyof Fields]: ZodValidatorFromConvex<Fields[K]>;
-                      },
-                      "strip"
-                    >
-                  : V extends VRecord<any, infer Key, infer Value, any, any>
-                    ? Key extends VId<GenericId<infer TableName>>
-                      ? z.ZodRecord<
-                          Zid<TableName>,
-                          ZodValidatorFromConvex<Value>
-                        >
-                      : z.ZodRecord<z.ZodString, ZodValidatorFromConvex<Value>>
-                    : V extends VArray<any, any>
-                      ? z.ZodArray<ZodValidatorFromConvex<V["element"]>>
-                      : V extends VUnion<
-                            any,
-                            [
-                              infer A extends GenericValidator,
-                              infer B extends GenericValidator,
-                              ...infer Rest extends GenericValidator[],
-                            ],
-                            any,
-                            any
+          : V extends VCommitTs<any, any>
+            ? z.ZodUnion<[z.ZodBigInt, z.ZodType<CommitTsPlaceholder>]>
+            : V extends VBoolean<any, any>
+              ? z.ZodBoolean
+              : V extends VNull<any, any>
+                ? z.ZodNull
+                : V extends VLiteral<infer T, any>
+                  ? z.ZodLiteral<T>
+                  : V extends VObject<any, infer Fields, any, any>
+                    ? z.ZodObject<
+                        {
+                          [K in keyof Fields]: ZodValidatorFromConvex<
+                            Fields[K]
+                          >;
+                        },
+                        "strip"
+                      >
+                    : V extends VRecord<any, infer Key, infer Value, any, any>
+                      ? Key extends VId<GenericId<infer TableName>>
+                        ? z.ZodRecord<
+                            Zid<TableName>,
+                            ZodValidatorFromConvex<Value>
                           >
-                        ? z.ZodUnion<
-                            [
-                              ZodValidatorFromConvex<A>,
-                              ZodValidatorFromConvex<B>,
-                              ...{
-                                [K in keyof Rest]: ZodValidatorFromConvex<
-                                  Rest[K]
-                                >;
-                              },
-                            ]
+                        : z.ZodRecord<
+                            z.ZodString,
+                            ZodValidatorFromConvex<Value>
                           >
-                        : z.ZodTypeAny; // fallback for unknown validators
+                      : V extends VArray<any, any>
+                        ? z.ZodArray<ZodValidatorFromConvex<V["element"]>>
+                        : V extends VUnion<
+                              any,
+                              [
+                                infer A extends GenericValidator,
+                                infer B extends GenericValidator,
+                                ...infer Rest extends GenericValidator[],
+                              ],
+                              any,
+                              any
+                            >
+                          ? z.ZodUnion<
+                              [
+                                ZodValidatorFromConvex<A>,
+                                ZodValidatorFromConvex<B>,
+                                ...{
+                                  [K in keyof Rest]: ZodValidatorFromConvex<
+                                    Rest[K]
+                                  >;
+                                },
+                              ]
+                            >
+                          : z.ZodTypeAny; // fallback for unknown validators
 
 /**
  * Better type conversion from a Convex validator to a Zod validator
@@ -1703,6 +1711,9 @@ export function convexToZod<V extends GenericValidator>(
       break;
     case "int64":
       zodValidator = z.bigint();
+      break;
+    case "commitTs":
+      zodValidator = z.union([z.bigint(), z.instanceof(CommitTsPlaceholder)]);
       break;
     case "boolean":
       zodValidator = z.boolean();

--- a/packages/convex-helpers/server/zod4.convextozod.test.ts
+++ b/packages/convex-helpers/server/zod4.convextozod.test.ts
@@ -2,6 +2,7 @@ import * as zCore from "zod/v4/core";
 import * as z from "zod/v4";
 import { assertType, describe, expect, expectTypeOf, test } from "vitest";
 import {
+  CommitTsPlaceholder,
   GenericId,
   GenericValidator,
   Infer,
@@ -25,6 +26,13 @@ describe("convexToZod", () => {
   test("string", () => testConvexToZod(v.string(), z.string()));
   test("number", () => testConvexToZod(v.number(), z.number()));
   test("int64", () => testConvexToZod(v.int64(), z.bigint()));
+  test("commitTs", () => {
+    const _expected = z.union([z.bigint(), z.instanceof(CommitTsPlaceholder)]);
+    const actual = convexToZod(v.commitTs());
+    expectTypeOf(actual).toEqualTypeOf<typeof _expected>();
+    expect(actual.safeParse(1n).success).toBe(true);
+    expect(actual.safeParse(new CommitTsPlaceholder()).success).toBe(true);
+  });
   test("boolean", () => testConvexToZod(v.boolean(), z.boolean()));
   test("null", () => testConvexToZod(v.null(), z.null()));
   test("any", () => testConvexToZod(v.any(), z.any()));

--- a/packages/convex-helpers/server/zod4.ts
+++ b/packages/convex-helpers/server/zod4.ts
@@ -1,4 +1,4 @@
-import { ConvexError, v } from "convex/values";
+import { CommitTsPlaceholder, ConvexError, v } from "convex/values";
 import type {
   GenericId,
   GenericValidator,
@@ -11,6 +11,7 @@ import type {
   VArray,
   VBoolean,
   VBytes,
+  VCommitTs,
   VFloat64,
   VId,
   VInt64,
@@ -641,6 +642,9 @@ export function convexToZod<V extends GenericValidator>(
       break;
     case "int64":
       zodValidator = z.bigint();
+      break;
+    case "commitTs":
+      zodValidator = z.union([z.bigint(), z.instanceof(CommitTsPlaceholder)]);
       break;
     case "boolean":
       zodValidator = z.boolean();
@@ -1823,98 +1827,108 @@ export type ZodFromValidatorBase<V extends GenericValidator> =
         ? BrandIfBranded<T, z.ZodNumber>
         : V extends VInt64<any>
           ? z.ZodBigInt
-          : V extends VBoolean<any>
-            ? z.ZodBoolean
-            : V extends VNull<any>
-              ? z.ZodNull
-              : V extends VArray<any, infer Element>
-                ? Element extends VArray<any, any> // This check is used to avoid TypeScript complaining about infinite type instantiation
-                  ? z.ZodArray<zCore.SomeType>
-                  : z.ZodArray<ZodFromValidatorBase<Element>>
-                : V extends VObject<
-                      any,
-                      infer Fields extends Record<string, GenericValidator>
-                    >
-                  ? z.ZodObject<ZodShapeFromConvexObject<Fields>, zCore.$strict>
-                  : V extends VBytes<any, any>
-                    ? never
-                    : V extends VLiteral<
-                          infer T extends zCore.util.Literal,
-                          OptionalProperty
-                        >
-                      ? z.ZodLiteral<NotUndefined<T>>
-                      : V extends VRecord<
-                            any,
-                            infer Key,
-                            infer Value,
-                            OptionalProperty,
-                            any
+          : V extends VCommitTs<any>
+            ? z.ZodUnion<
+                readonly [
+                  z.ZodBigInt,
+                  z.ZodCustom<CommitTsPlaceholder, CommitTsPlaceholder>,
+                ]
+              >
+            : V extends VBoolean<any>
+              ? z.ZodBoolean
+              : V extends VNull<any>
+                ? z.ZodNull
+                : V extends VArray<any, infer Element>
+                  ? Element extends VArray<any, any> // This check is used to avoid TypeScript complaining about infinite type instantiation
+                    ? z.ZodArray<zCore.SomeType>
+                    : z.ZodArray<ZodFromValidatorBase<Element>>
+                  : V extends VObject<
+                        any,
+                        infer Fields extends Record<string, GenericValidator>
+                      >
+                    ? z.ZodObject<
+                        ZodShapeFromConvexObject<Fields>,
+                        zCore.$strict
+                      >
+                    : V extends VBytes<any, any>
+                      ? never
+                      : V extends VLiteral<
+                            infer T extends zCore.util.Literal,
+                            OptionalProperty
                           >
-                        ? z.ZodRecord<
-                            ZodFromStringValidator<Key>,
-                            ZodFromValidatorBase<Value>
-                          >
-                        : // Union: must handle separately cases for 0/1/2+ elements
-                          // instead of simply writing it as
-                          // V extends VUnion<any, infer Elements extends GenericValidator[], any, any>
-                          //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                          //   ? z.ZodUnion<{ [k in keyof Elements]: ZodValidatorFromConvex<Elements[k]> }>
-                          //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                          // because the TypeScript compiler would complain about infinite type instantiation otherwise :(
-                          V extends VUnion<any, [], OptionalProperty, any>
-                          ? z.ZodNever
-                          : V extends VUnion<
-                                any,
-                                [infer I extends GenericValidator],
-                                OptionalProperty,
-                                any
-                              >
-                            ? ZodValidatorFromConvex<I>
+                        ? z.ZodLiteral<NotUndefined<T>>
+                        : V extends VRecord<
+                              any,
+                              infer Key,
+                              infer Value,
+                              OptionalProperty,
+                              any
+                            >
+                          ? z.ZodRecord<
+                              ZodFromStringValidator<Key>,
+                              ZodFromValidatorBase<Value>
+                            >
+                          : // Union: must handle separately cases for 0/1/2+ elements
+                            // instead of simply writing it as
+                            // V extends VUnion<any, infer Elements extends GenericValidator[], any, any>
+                            //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            //   ? z.ZodUnion<{ [k in keyof Elements]: ZodValidatorFromConvex<Elements[k]> }>
+                            //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            // because the TypeScript compiler would complain about infinite type instantiation otherwise :(
+                            V extends VUnion<any, [], OptionalProperty, any>
+                            ? z.ZodNever
                             : V extends VUnion<
                                   any,
-                                  [
-                                    infer A extends GenericValidator,
-                                    ...infer Rest extends GenericValidator[],
-                                  ],
+                                  [infer I extends GenericValidator],
                                   OptionalProperty,
                                   any
                                 >
-                              ? z.ZodUnion<
-                                  readonly [
-                                    ZodValidatorFromConvex<A>,
-                                    ...{
-                                      [K in keyof Rest]: ZodValidatorFromConvex<
-                                        Rest[K]
-                                      >;
-                                    },
-                                  ]
-                                >
-                              : // Fallback for unions whose members are a
-                                // generic array (e.g. `VLiteral<X>[]`) rather
-                                // than a tuple. That happens when callers
-                                // spread an array into `v.union(...)` and
-                                // TypeScript cannot recover the tuple shape;
-                                // the order is unknown, so we widen to a
-                                // generic-array union of the element
-                                // validator. The `[GenericValidator] extends [E]`
-                                // guard avoids infinite recursion when `E` is the
-                                // maximally-generic validator type — that
-                                // happens during recursive type evaluation of
-                                // `convexToZod` itself.
-                                V extends VUnion<
+                              ? ZodValidatorFromConvex<I>
+                              : V extends VUnion<
                                     any,
-                                    (infer E extends GenericValidator)[],
+                                    [
+                                      infer A extends GenericValidator,
+                                      ...infer Rest extends GenericValidator[],
+                                    ],
                                     OptionalProperty,
                                     any
                                   >
-                                ? [GenericValidator] extends [E]
-                                  ? z.ZodUnion<readonly zCore.SomeType[]>
-                                  : z.ZodUnion<
-                                      readonly ZodValidatorFromConvex<E>[]
+                                ? z.ZodUnion<
+                                    readonly [
+                                      ZodValidatorFromConvex<A>,
+                                      ...{
+                                        [K in keyof Rest]: ZodValidatorFromConvex<
+                                          Rest[K]
+                                        >;
+                                      },
+                                    ]
+                                  >
+                                : // Fallback for unions whose members are a
+                                  // generic array (e.g. `VLiteral<X>[]`) rather
+                                  // than a tuple. That happens when callers
+                                  // spread an array into `v.union(...)` and
+                                  // TypeScript cannot recover the tuple shape;
+                                  // the order is unknown, so we widen to a
+                                  // generic-array union of the element
+                                  // validator. The `[GenericValidator] extends [E]`
+                                  // guard avoids infinite recursion when `E` is the
+                                  // maximally-generic validator type — that
+                                  // happens during recursive type evaluation of
+                                  // `convexToZod` itself.
+                                  V extends VUnion<
+                                      any,
+                                      (infer E extends GenericValidator)[],
+                                      OptionalProperty,
+                                      any
                                     >
-                                : V extends VAny<any, OptionalProperty, any>
-                                  ? z.ZodAny
-                                  : never;
+                                  ? [GenericValidator] extends [E]
+                                    ? z.ZodUnion<readonly zCore.SomeType[]>
+                                    : z.ZodUnion<
+                                        readonly ZodValidatorFromConvex<E>[]
+                                      >
+                                  : V extends VAny<any, OptionalProperty, any>
+                                    ? z.ZodAny
+                                    : never;
 
 type BrandIfBranded<InnerType, Validator extends zCore.SomeType> =
   InnerType extends zCore.$brand<infer Brand>

--- a/packages/convex-helpers/validators.test.ts
+++ b/packages/convex-helpers/validators.test.ts
@@ -74,6 +74,10 @@ describe("vRequired", () => {
     testVRequired(v.optional(v.int64()), v.int64());
   });
 
+  test("converts optional commitTs to required", () => {
+    testVRequired(v.optional(v.commitTs()), v.commitTs());
+  });
+
   test("converts optional null to required", () => {
     testVRequired(v.optional(v.null()), v.null());
   });

--- a/packages/convex-helpers/validators.ts
+++ b/packages/convex-helpers/validators.ts
@@ -18,6 +18,7 @@ import type {
   VArray,
   VBoolean,
   VBytes,
+  VCommitTs,
   VFloat64,
   VId,
   VInt64,
@@ -930,61 +931,63 @@ export type VRequired<T extends Validator<any, OptionalProperty, any>> =
         ? VFloat64<NotUndefined<Type>, "required">
         : T extends VInt64<infer Type, OptionalProperty>
           ? VInt64<NotUndefined<Type>, "required">
-          : T extends VBoolean<infer Type, OptionalProperty>
-            ? VBoolean<NotUndefined<Type>, "required">
-            : T extends VNull<infer Type, OptionalProperty>
-              ? VNull<NotUndefined<Type>, "required">
-              : T extends VAny<infer Type, OptionalProperty>
-                ? VAny<NotUndefined<Type>, "required">
-                : T extends VLiteral<infer Type, OptionalProperty>
-                  ? VLiteral<NotUndefined<Type>, "required">
-                  : T extends VBytes<infer Type, OptionalProperty>
-                    ? VBytes<NotUndefined<Type>, "required">
-                    : T extends VObject<
-                          infer Type,
-                          infer Fields,
-                          OptionalProperty,
-                          infer FieldPaths
-                        >
-                      ? VObject<
-                          NotUndefined<Type>,
-                          Fields,
-                          "required",
-                          FieldPaths
-                        >
-                      : T extends VArray<
+          : T extends VCommitTs<infer Type, OptionalProperty>
+            ? VCommitTs<NotUndefined<Type>, "required">
+            : T extends VBoolean<infer Type, OptionalProperty>
+              ? VBoolean<NotUndefined<Type>, "required">
+              : T extends VNull<infer Type, OptionalProperty>
+                ? VNull<NotUndefined<Type>, "required">
+                : T extends VAny<infer Type, OptionalProperty>
+                  ? VAny<NotUndefined<Type>, "required">
+                  : T extends VLiteral<infer Type, OptionalProperty>
+                    ? VLiteral<NotUndefined<Type>, "required">
+                    : T extends VBytes<infer Type, OptionalProperty>
+                      ? VBytes<NotUndefined<Type>, "required">
+                      : T extends VObject<
                             infer Type,
-                            infer Element,
-                            OptionalProperty
+                            infer Fields,
+                            OptionalProperty,
+                            infer FieldPaths
                           >
-                        ? VArray<NotUndefined<Type>, Element, "required">
-                        : T extends VRecord<
+                        ? VObject<
+                            NotUndefined<Type>,
+                            Fields,
+                            "required",
+                            FieldPaths
+                          >
+                        : T extends VArray<
                               infer Type,
-                              infer Key,
-                              infer Value,
-                              OptionalProperty,
-                              infer FieldPaths
+                              infer Element,
+                              OptionalProperty
                             >
-                          ? VRecord<
-                              NotUndefined<Type>,
-                              Key,
-                              Value,
-                              "required",
-                              FieldPaths
-                            >
-                          : T extends VUnion<
+                          ? VArray<NotUndefined<Type>, Element, "required">
+                          : T extends VRecord<
                                 infer Type,
-                                infer Members,
+                                infer Key,
+                                infer Value,
                                 OptionalProperty,
                                 infer FieldPaths
                               >
-                            ? VUnion<
+                            ? VRecord<
                                 NotUndefined<Type>,
-                                Members,
+                                Key,
+                                Value,
                                 "required",
                                 FieldPaths
                               >
-                            : never;
+                            : T extends VUnion<
+                                  infer Type,
+                                  infer Members,
+                                  OptionalProperty,
+                                  infer FieldPaths
+                                >
+                              ? VUnion<
+                                  NotUndefined<Type>,
+                                  Members,
+                                  "required",
+                                  FieldPaths
+                                >
+                              : never;
 
 /**
  * Converts an optional validator to a required validator.
@@ -1040,6 +1043,8 @@ export function vRequired<T extends Validator<any, OptionalProperty, any>>(
       return v.record(validator.key, validator.value) as VRequired<T>;
     case "union":
       return v.union(...validator.members) as VRequired<T>;
+    case "commitTs":
+      return v.commitTs() as VRequired<T>;
     default:
       kind satisfies never;
       throw new Error("Unknown Convex validator type: " + kind);


### PR DESCRIPTION
Updates api spec generators, zod, and other helpers to handle the new `v.commitTs()` validator. Also updates RLS and triggers to include the newly added `vars` inside `db`. Bumps the convex peer dependency to convex 1.43.0.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
